### PR TITLE
Use `config.ron` as default with `include_str!`, add audio/status area applets

### DIFF
--- a/config.ron
+++ b/config.ron
@@ -17,11 +17,13 @@
                     "com.system76.CosmicAppletWorkspaces",
                 ],
                 [
+                    "com.system76.CosmicAppletAudio",
                     "com.system76.CosmicAppletNetwork",
                     "com.system76.CosmicAppletGraphics",
                     "com.system76.CosmicAppletBattery",
                     "com.system76.CosmicAppletNotifications",
                     "com.system76.CosmicAppletPower",
+                    "com.system76.CosmicAppletStatusArea",
                 ]
             )),
             expand_to_edges: true,

--- a/cosmic-panel-config/src/container_config.rs
+++ b/cosmic-panel-config/src/container_config.rs
@@ -73,56 +73,6 @@ impl CosmicPanelContainerConfig {
 
 impl Default for CosmicPanelContainerConfig {
     fn default() -> Self {
-        Self {
-            config_list: vec![
-                CosmicPanelConfig {
-                    name: "panel".to_string(),
-                    anchor: PanelAnchor::Top,
-                    anchor_gap: false,
-                    layer: Layer::Top,
-                    keyboard_interactivity: KeyboardInteractivity::OnDemand,
-                    size: PanelSize::XS,
-                    output: CosmicPanelOuput::All,
-                    background: CosmicPanelBackground::Color([0.2, 0.2, 0.2, 0.8]),
-                    plugins_wings: Some((
-                        vec!["com.system76.CosmicAppletWorkspaces".to_string()],
-                        vec![
-                            "com.system76.CosmicAppletNetwork".to_string(),
-                            "com.system76.CosmicAppletGraphics".to_string(),
-                            "com.system76.CosmicAppletBattery".to_string(),
-                            "com.system76.CosmicAppletNotifications".to_string(),
-                            "com.system76.CosmicAppletPower".to_string(),
-                        ],
-                    )),
-                    plugins_center: Some(vec!["com.system76.CosmicAppletTime".to_string()]),
-                    expand_to_edges: false,
-                    padding: 2,
-                    spacing: 2,
-                    exclusive_zone: true,
-                    autohide: None,
-                },
-                CosmicPanelConfig {
-                    name: "dock".to_string(),
-                    anchor: PanelAnchor::Bottom,
-                    anchor_gap: false,
-                    layer: Layer::Top,
-                    keyboard_interactivity: KeyboardInteractivity::OnDemand,
-                    size: PanelSize::L,
-                    output: CosmicPanelOuput::All,
-                    background: CosmicPanelBackground::Color([0.2, 0.2, 0.2, 0.8]),
-                    plugins_center: Some(vec!["com.system76.CosmicAppList".to_string()]),
-                    plugins_wings: None,
-                    expand_to_edges: true,
-                    padding: 4,
-                    spacing: 4,
-                    exclusive_zone: false,
-                    autohide: Some(AutoHide {
-                        wait_time: 500,
-                        transition_time: 200,
-                        handle_size: 2,
-                    }),
-                },
-            ],
-        }
+        ron::de::from_str(include_str!("../../config.ron")).unwrap()
     }
 }


### PR DESCRIPTION
CI is failing already on `master_jammy`. I'm not sure what issue it has with the `smithay-client-toolkit` dependency, since `Cargo.lock` only has it depending on one version, with a commit that should be fine...