### PR TITLE
chore(config): remove libcosmic rev for cosmic-settings

### DIFF
--- a/cosmic-panel-config/Cargo.toml
+++ b/cosmic-panel-config/Cargo.toml
@@ -13,7 +13,7 @@ ron = "0.8.0"
 serde = { version = "1.0.152", features = ["derive"] }
 tracing = "0.1.37"
 wayland-protocols-wlr = { version = "0.1.0", features = ["server"], optional = true}
-cosmic-config = { git = "https://github.com/pop-os/libcosmic", rev = "f06a81c" }
+cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 # xdg-shell-wrapper-config = { path = "../../xdg-shell-wrapper/xdg-shell-wrapper-config", optional = true }
 xdg-shell-wrapper-config = { git = "https://github.com/pop-os/xdg-shell-wrapper", optional = true, rev = "99a9cda" }
 


### PR DESCRIPTION
Allows using it as a dependency in cosmic-settings so that cosmic-settings can make the decision about the version of cosmic-config and libcosmic to use.