### PR TITLE
fix: restart applets properly

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -48,6 +48,8 @@ impl PanelSpace {
             .filter(|w| w.alive())
             .filter_map(|w| {
                 self.clients_right
+                    .lock()
+                    .unwrap()
                     .iter()
                     .enumerate()
                     .find_map(|(i, (_, c, _))| {
@@ -68,6 +70,8 @@ impl PanelSpace {
             .filter(|w| w.alive())
             .filter_map(|w| {
                 self.clients_center
+                    .lock()
+                    .unwrap()
                     .iter()
                     .enumerate()
                     .find_map(|(i, (_, c, _))| {
@@ -88,6 +92,8 @@ impl PanelSpace {
             .filter(|w| w.alive())
             .filter_map(|w| {
                 self.clients_left
+                    .lock()
+                    .unwrap()
                     .iter()
                     .enumerate()
                     .find_map(|(i, (_, c, _))| {

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -2,6 +2,7 @@ use std::{
     cell::{Cell, RefCell},
     os::{fd::RawFd, unix::net::UnixStream},
     rc::Rc,
+    sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
 
@@ -75,9 +76,9 @@ use cosmic_panel_config::{CosmicPanelBackground, CosmicPanelConfig, PanelAnchor}
 
 pub enum AppletMsg {
     NewProcess(ObjectId, Process),
-    NewNotificationsProcess(ObjectId, Process, Vec<(String, String)>),
+    NewNotificationsProcess(ObjectId, Process, Vec<(String, String)>, RawFd),
     NeedNewNotificationFd(oneshot::Sender<RawFd>),
-    ClientSocketPair(String, ClientId, Client, UnixStream),
+    ClientSocketPair(ClientId),
     Cleanup(ObjectId),
 }
 
@@ -96,9 +97,9 @@ pub(crate) struct PanelSpace {
     pub config: CosmicPanelConfig,
     pub(crate) space: Space<Window>,
     pub(crate) damage_tracked_renderer: Option<OutputDamageTracker>,
-    pub(crate) clients_left: Vec<(String, Client, UnixStream)>,
-    pub(crate) clients_center: Vec<(String, Client, UnixStream)>,
-    pub(crate) clients_right: Vec<(String, Client, UnixStream)>,
+    pub(crate) clients_left: Arc<Mutex<Vec<(String, Client, UnixStream)>>>,
+    pub(crate) clients_center: Arc<Mutex<Vec<(String, Client, UnixStream)>>>,
+    pub(crate) clients_right: Arc<Mutex<Vec<(String, Client, UnixStream)>>>,
     pub(crate) last_dirty: Option<Instant>,
     // pending size of the panel
     pub(crate) pending_dimensions: Option<Size<i32, Logical>>,

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -279,9 +279,11 @@ impl WrapperSpace for SpaceContainer {
         if let Some(space) = self.space_list.iter_mut().find(|space| {
             space
                 .clients_center
+                .lock()
+                .unwrap()
                 .iter()
-                .chain(space.clients_left.iter())
-                .chain(space.clients_right.iter())
+                .chain(space.clients_left.lock().unwrap().iter())
+                .chain(space.clients_right.lock().unwrap().iter())
                 .any(|(_, c, _)| Some(c.id()) == w_client)
         }) {
             space.add_window(s_top_level);
@@ -306,9 +308,11 @@ impl WrapperSpace for SpaceContainer {
         if let Some(space) = self.space_list.iter_mut().find(|space| {
             space
                 .clients_center
+                .lock()
+                .unwrap()
                 .iter()
-                .chain(space.clients_left.iter())
-                .chain(space.clients_right.iter())
+                .chain(space.clients_left.lock().unwrap().iter())
+                .chain(space.clients_right.lock().unwrap().iter())
                 .any(|(_, c, _)| Some(c.id()) == p_client)
         }) {
             space.add_popup(
@@ -339,9 +343,11 @@ impl WrapperSpace for SpaceContainer {
         if let Some(space) = self.space_list.iter_mut().find(|space| {
             space
                 .clients_center
+                .lock()
+                .unwrap()
                 .iter()
-                .chain(space.clients_left.iter())
-                .chain(space.clients_right.iter())
+                .chain(space.clients_left.lock().unwrap().iter())
+                .chain(space.clients_right.lock().unwrap().iter())
                 .any(|(_, c, _)| Some(c.id()) == p_client)
         }) {
             space.reposition_popup(popup, positioner_state, token)?
@@ -402,9 +408,11 @@ impl WrapperSpace for SpaceContainer {
         if let Some(space) = self.space_list.iter_mut().find(|space| {
             space
                 .clients_center
+                .lock()
+                .unwrap()
                 .iter()
-                .chain(space.clients_left.iter())
-                .chain(space.clients_right.iter())
+                .chain(space.clients_left.lock().unwrap().iter())
+                .chain(space.clients_right.lock().unwrap().iter())
                 .any(|(_, c, _)| Some(c.id()) == w_client)
         }) {
             space.dirty_window(dh, w);
@@ -422,9 +430,11 @@ impl WrapperSpace for SpaceContainer {
         if let Some(space) = self.space_list.iter_mut().find(|space| {
             space
                 .clients_center
+                .lock()
+                .unwrap()
                 .iter()
-                .chain(space.clients_left.iter())
-                .chain(space.clients_right.iter())
+                .chain(space.clients_left.lock().unwrap().iter())
+                .chain(space.clients_right.lock().unwrap().iter())
                 .any(|(_, c, _)| Some(c.id()) == p_client)
         }) {
             space.dirty_popup(dh, w);


### PR DESCRIPTION
applet restarts failed due to a race not being properly prevented. The client list in the panel needs to be updated before it can be restarted by launchpad.