### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,17 +465,14 @@ dependencies = [
  "log-panics",
  "notify",
  "ron",
- "sendfd",
  "serde",
  "shlex",
  "smithay",
  "smithay-client-toolkit",
  "tokio",
  "tracing",
- "tracing-futures",
  "tracing-journald",
  "tracing-subscriber",
- "transpose",
  "wayland-egl",
  "wayland-protocols",
  "wayland-protocols-wlr",
@@ -1727,26 +1724,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.38",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,15 +2062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sendfd"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604b71b8fc267e13bb3023a2c901126c8f349393666a6d98ac1ae5729b701798"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,12 +2266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "strength_reduce"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
-
-[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,16 +2455,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-journald"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,16 +2492,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "transpose"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6522d49d03727ffb138ae4cbc1283d3774f0d10aa7f9bf52e6784c45daf9b23"
-dependencies = [
- "num-integer",
- "strength_reduce",
 ]
 
 [[package]]

--- a/cosmic-panel-bin/Cargo.toml
+++ b/cosmic-panel-bin/Cargo.toml
@@ -26,12 +26,10 @@ wayland-protocols-wlr = { version = "0.2.0", features = ["client"] }
 tracing = "0.1.37"
 tracing-subscriber = {version = "0.3.16", features = ["fmt", "env-filter", "ansi"]}
 tracing-journald = "0.3.0"
-tracing-futures = "0.2.5"
 launch-pad = { git = "https://github.com/pop-os/launch-pad.git" }
 # launch-pad = { path = "../../launch-pad" }
 cosmic-panel-config = { path = "../cosmic-panel-config" }
 cosmic-theme = { git = "https://github.com/pop-os/libcosmic", package = "cosmic-theme" }
-transpose = "0.2.2"
 anyhow = "1.0.63"
 shlex = "1.1.0"
 log-panics = { version = "2", features = ["with-backtrace"] }
@@ -45,7 +43,6 @@ csscolorparser = "0.6.2"
 image = "0.24"
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 ron = "0.8"
-sendfd = "0.4"
 cosmic-notifications-util = { git = "https://github.com/pop-os/cosmic-notifications", default-features = false }
 serde = "1.0"
 bytemuck = "1.13"


### PR DESCRIPTION
`tracing-futures`, `transpose`, and `sendfd` are all unused. This PR removes them.