### PR TITLE
chore: disable dock autohide by default

### DIFF
--- a/data/default_schema/com.system76.CosmicPanel.Dock/v1/autohide
+++ b/data/default_schema/com.system76.CosmicPanel.Dock/v1/autohide
@@ -1,1 +1,1 @@
-Some((wait_time:500,transition_time:200,handle_size:2))
+None


### PR DESCRIPTION
fixes #116 