### PR TITLE
fix: unmap applets whose size is too large, and map them again when possible

### DIFF
--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -928,7 +928,7 @@ impl WrapperSpace for PanelSpace {
         info: OutputInfo,
     ) -> anyhow::Result<bool> {
         self.output.replace((c_output, s_output, info));
-        self.dimensions = self.constrain_dim(self.dimensions.clone());
+        self.dimensions = self.constrain_dim(self.dimensions.clone(), Some(self.gap() as u32));
         self.is_dirty = true;
         Ok(true)
     }
@@ -969,7 +969,8 @@ impl WrapperSpace for PanelSpace {
         } else if !matches!(self.config.output, CosmicPanelOuput::Active) {
             bail!("output does not match config");
         }
-        let dimensions: Size<i32, Logical> = self.constrain_dim((0, 0).into());
+        let dimensions: Size<i32, Logical> =
+            self.constrain_dim((0, 0).into(), Some(self.gap() as u32));
 
         let layer = match self.config().layer() {
             zwlr_layer_shell_v1::Layer::Background => Layer::Background,

--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -488,16 +488,17 @@ impl CosmicPanelConfig {
         &self,
         output_dims: Option<(u32, u32)>,
         suggested_length: Option<u32>,
+        gap: Option<u32>,
     ) -> (Option<Range<u32>>, Option<Range<u32>>) {
-        let mut bar_thickness = match &self.size {
-            PanelSize::XS => 8..61,
-            PanelSize::S => 8..81,
-            PanelSize::M => 8..101,
-            PanelSize::L => 8..121,
-            PanelSize::XL => 8..141,
+        let gap = gap.unwrap_or_else(|| self.get_effective_anchor_gap());
+        let bar_thickness = match &self.size {
+            PanelSize::XS => 8 + gap..61 + gap,
+            PanelSize::S => 8 + gap..81 + gap,
+            PanelSize::M => 8 + gap..101 + gap,
+            PanelSize::L => 8 + gap..121 + gap,
+            PanelSize::XL => 8 + gap..141 + gap,
         };
-        assert!(2 * self.padding < bar_thickness.end);
-        bar_thickness.end -= 2 * self.padding;
+        assert!(2 * self.padding + gap < bar_thickness.end);
         let o_h = suggested_length.unwrap_or_else(|| output_dims.unwrap_or_default().1);
         let o_w = suggested_length.unwrap_or_else(|| output_dims.unwrap_or_default().0);
 


### PR DESCRIPTION
This also accounts for the active gap when constraining sizes. Should fix #138