### PR TITLE
fix: preserve non-maximized config for autohide panels/docks

### DIFF
--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -537,10 +537,13 @@ impl CosmicPanelConfig {
     }
 
     pub fn maximize(&mut self) {
+        self.opacity = 1.0;
+        if self.autohide().is_some() {
+            return;
+        }
         self.expand_to_edges = true;
         self.margin = 0;
         self.border_radius = 0;
-        self.opacity = 1.0;
         self.anchor_gap = false;
     }
 }


### PR DESCRIPTION
This PR fixes the behavior of autohide panels/docks when a maximized window is focused.

Previously, the panel/dock would expand itself to the edges, regardless of whether the setting is turned off in the settings. While this is appropriate for regular panels, autohide panels/docks should not expand to edges unless it's set that way in settings.


https://github.com/pop-os/cosmic-panel/assets/56272643/0d47bdaa-59ae-4c6f-8c6a-b8342fc2218e

