### PR TITLE
fix: prevent unmapping windows when downscaling

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -106,9 +106,14 @@ impl PanelSpace {
                 self.unmapped.push(w);
             }
         }
-        for w in to_unmap {
-            self.space.unmap_elem(&w);
-            self.unmapped.push(w);
+        // HACK temporarily avoid unmapping windows when changing scale
+        if to_unmap.len() > 0 && self.scale_change_retries == 0 {
+            for w in to_unmap {
+                self.space.unmap_elem(&w);
+                self.unmapped.push(w);
+            }
+        } else {
+            self.scale_change_retries -= 1;
         }
 
         self.space.refresh();

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -257,6 +257,7 @@ pub(crate) struct PanelSpace {
     pub(crate) generated_pointer_events: Vec<PointerEvent>,
     // Counter for handling of generated pointer events
     pub(crate) generated_ptr_event_count: usize,
+    pub scale_change_retries: u32,
 }
 
 impl PanelSpace {
@@ -320,6 +321,7 @@ impl PanelSpace {
             panel_rect_settings: RoundedRectangleSettings::default(),
             generated_pointer_events: Vec::new(),
             generated_ptr_event_count: 0,
+            scale_change_retries: 0,
         }
     }
 
@@ -785,6 +787,16 @@ impl PanelSpace {
             if prev == self.popups.len() && should_render {
                 if let Err(e) = self.render(renderer, time, qh) {
                     error!("Failed to render, error: {:?}", e);
+                }
+            } else {
+                for w in &self.unmapped {
+                    let output = self.output.as_ref().unwrap().1.clone();
+                    w.send_frame(
+                        &output,
+                        Duration::from_millis(time as u64),
+                        Some(Duration::from_millis(time as u64)),
+                        |_, _| Some(output.clone()),
+                    );
                 }
             }
         }

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -1183,6 +1183,7 @@ impl WrapperSpace for PanelSpace {
                 .unwrap_or_else(|| "None".to_string())
         );
         if Some(surface) == self.layer.as_ref().map(|l| l.wl_surface()) {
+            self.scale_change_retries = 10;
             self.scale = scale;
             self.is_dirty = true;
             if legacy && self.layer_fractional_scale.is_none() {


### PR DESCRIPTION
fixes #173 