### PR TITLE
WIP Support for touch input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,7 +2985,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/xdg-shell-wrapper#b5480042615ecfcf30262d5a40625e8f430b474a"
+source = "git+https://github.com/pop-os/xdg-shell-wrapper?branch=touch#35f1bbe6efeb49a7504c143c9c1fd798cdb5fb2d"
 dependencies = [
  "anyhow",
  "cosmic-client-toolkit",
@@ -3010,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "xdg-shell-wrapper-config"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/xdg-shell-wrapper#b5480042615ecfcf30262d5a40625e8f430b474a"
+source = "git+https://github.com/pop-os/xdg-shell-wrapper?branch=touch#35f1bbe6efeb49a7504c143c9c1fd798cdb5fb2d"
 dependencies = [
  "serde",
  "wayland-protocols-wlr",

--- a/cosmic-panel-bin/Cargo.toml
+++ b/cosmic-panel-bin/Cargo.toml
@@ -20,8 +20,8 @@ smithay = { git = "https://github.com/smithay/smithay", default-features = false
 sctk.workspace = true
 # sctk = { package = "smithay-client-toolkit", path = "../../fork/client-toolkit", default-features = false, features = ["calloop", "xkbcommon"] }
 wayland-protocols = { version = "0.31.0", features = ["staging"] }
-xdg-shell-wrapper-config = { git = "https://github.com/pop-os/xdg-shell-wrapper" }
-xdg-shell-wrapper = { git = "https://github.com/pop-os/xdg-shell-wrapper" }
+xdg-shell-wrapper-config = { git = "https://github.com/pop-os/xdg-shell-wrapper", branch = "touch" }
+xdg-shell-wrapper = { git = "https://github.com/pop-os/xdg-shell-wrapper", branch = "touch" }
 # xdg-shell-wrapper = { path = "../../xdg-shell-wrapper" }
 # xdg-shell-wrapper-config = { path = "../../xdg-shell-wrapper/xdg-shell-wrapper-config" }
 cctk = { package = "cosmic-client-toolkit", git = "https://github.com/pop-os/cosmic-protocols", rev = "e65fa5e" }

--- a/cosmic-panel-config/Cargo.toml
+++ b/cosmic-panel-config/Cargo.toml
@@ -14,6 +14,6 @@ tracing = "0.1.37"
 wayland-protocols-wlr = { version = "0.2.0", features = ["server", "client"], optional = true}
 cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 # xdg-shell-wrapper-config = { path = "../../xdg-shell-wrapper/xdg-shell-wrapper-config", optional = true }
-xdg-shell-wrapper-config = { git = "https://github.com/pop-os/xdg-shell-wrapper", optional = true }
+xdg-shell-wrapper-config = { git = "https://github.com/pop-os/xdg-shell-wrapper", branch = "touch", optional = true }
 sctk.workspace = true
 sctk.optional = true


### PR DESCRIPTION
Requires https://github.com/pop-os/xdg-shell-wrapper/pull/22.

Seems to be working now. And panel applets already support touch, since it was added to iced-sctk.

I want to see if `update_pointer` and this `touch_under` can be cleanup up and deduplicated a bit though... as well as a bit more testing.