### PR TITLE
fix: more refined config updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["cosmic-panel-bin", "cosmic-panel-config"]
+resolver = "2"
 
 [workspace.dependencies]
 sctk = { git = "https://github.com/smithay/client-toolkit", package = "smithay-client-toolkit", features = [

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -306,8 +306,8 @@ impl SpaceContainer {
             // Priority change to conflict with adjacent panel
             || c.name != entry.name
                 && Some(c.anchor) != opposite_anchor
-                && (old_priority < c.get_priority() && new_priority > c.get_priority() || old_priority > c.get_priority() && new_priority < c.get_priority())}
-            || old_priority != new_priority && c.anchor == entry.anchor
+                && ((old_priority < c.get_priority() && new_priority > c.get_priority() || old_priority > c.get_priority() && new_priority < c.get_priority()))}
+            || c.name != entry.name && old_priority != new_priority && c.anchor == entry.anchor
         );
 
         self.config.config_list.retain(|c| c.name != entry.name);


### PR DESCRIPTION
ensure that priority comparisons are only applied to adjecent panels, and not self