### PR TITLE
chore: add SPDX license identifier to Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 members = ["cosmic-panel-bin", "cosmic-panel-config"]
 
+[workspace.package]
+license = "GPL-3.0-only"
+
 [profile.release]
 lto = "thin"
 


### PR DESCRIPTION
If the project isn't GPL-3.0-only, let me know and I can modify the PR!