### PR TITLE
fix: convert usize to isize

### DIFF
--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -223,7 +223,7 @@ impl SpaceContainer {
             self.outputs.len()
         } else {
             self.space_list.iter().filter(|s| s.config.name == entry.name).count()
-        };
+        } as isize;
 
         if force_output.is_none()
             && self.space_list.iter_mut().any(|s| {


### PR DESCRIPTION
Removes clippy error and prevents potential usize underflow scenarios.
![clippy_error](https://github.com/user-attachments/assets/87b3ae0b-5e35-45ba-9405-f06527b09849)
