### PR TITLE
panel-config: Add border_width property

### DIFF
--- a/cosmic-panel-bin/src/config_watching.rs
+++ b/cosmic-panel-bin/src/config_watching.rs
@@ -112,7 +112,8 @@ pub fn watch_config(
             channel::Event::Msg(ConfigUpdate::Entries(entries)) => {
                 let to_update = entries
                     .iter()
-                    .filter(|c| !state.space.config.config_list.iter().any(|e| e.name == **c)).cloned()
+                    .filter(|c| !state.space.config.config_list.iter().any(|e| e.name == **c))
+                    .cloned()
                     .collect::<Vec<String>>();
                 info!("Received entries: {:?}", to_update);
                 for entry in to_update {

--- a/cosmic-panel-bin/src/iced/elements/background.rs
+++ b/cosmic-panel-bin/src/iced/elements/background.rs
@@ -26,6 +26,7 @@ pub fn background_element(
     panel_id: usize,
     logical_pos: [f32; 2],
     color: [f32; 4],
+    border_width: f32,
 ) -> BackgroundElement {
     IcedElement::new(
         Background {
@@ -35,6 +36,7 @@ pub fn background_element(
             radius,
             logical_pos: (logical_pos[0].round() as i32, logical_pos[1].round() as i32),
             color,
+            border_width,
         },
         (logical_width, logical_height),
         loop_handle,
@@ -51,6 +53,7 @@ pub struct Background {
     pub radius: [f32; 4],
     pub logical_pos: (i32, i32),
     pub color: [f32; 4],
+    pub border_width: f32,
 }
 
 impl Program for Background {
@@ -74,7 +77,7 @@ impl Program for Background {
                         background: Some(Color::from(color).into()),
                         border: cosmic::iced::Border {
                             radius: radius_arr.into(),
-                            width: 0.,
+                            width: self.border_width,
                             color: cosmic.background.divider.into(),
                         },
                         shadow: Shadow::default(),

--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -742,7 +742,7 @@ impl PanelSpace {
                 self.space.id(),
                 loc,
                 self.bg_color(),
-                self.config.border_width
+                self.config.border_width,
             );
             bg.output_enter(&output, Rectangle::default());
             self.background_element = Some(bg.clone());

--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -742,6 +742,7 @@ impl PanelSpace {
                 self.space.id(),
                 loc,
                 self.bg_color(),
+                self.config.border_width
             );
             bg.output_enter(&output, Rectangle::default());
             self.background_element = Some(bg.clone());

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -292,6 +292,8 @@ impl SpaceContainer {
             c.name == entry.name && c.size != entry.size
             // size overrides changed
             || (c.name == entry.name && (c.size_center != entry.size_center || c.size_wings != entry.size_wings))
+            // border width changed
+            || (c.name == entry.name && c.border_width != entry.border_width)
             // output changed
             || (entry.output != CosmicPanelOuput::All &&
             (c.name == entry.name && c.output != entry.output))

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/wp_security_context.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/wp_security_context.rs
@@ -54,10 +54,12 @@ impl SecurityContextManager {
         let addr = SocketAddr::from_abstract_name(s)?;
         // this also listens on the socket
         let listener = UnixListener::bind_addr(&addr)?;
-        let wp_security_context =
-            self.manager.create_listener(listener.as_fd(), close_fd.as_fd(), qh, SecurityContext {
-                conn: Arc::new(Mutex::new(None)),
-            });
+        let wp_security_context = self.manager.create_listener(
+            listener.as_fd(),
+            close_fd.as_fd(),
+            qh,
+            SecurityContext { conn: Arc::new(Mutex::new(None)) },
+        );
         let conn = UnixStream::connect_addr(&addr)?;
         // XXX make sure no one else can connect to the listener
         drop(close_fd_ours);

--- a/cosmic-panel-config/src/container_config.rs
+++ b/cosmic-panel-config/src/container_config.rs
@@ -158,6 +158,7 @@ impl Default for CosmicPanelContainerConfig {
                     padding: 0,
                     spacing: 2,
                     border_radius: 0,
+                    border_width: 0.0,
                     exclusive_zone: true,
                     autohide: None,
                     margin: 0,
@@ -187,6 +188,7 @@ impl Default for CosmicPanelContainerConfig {
                     padding: 0,
                     spacing: 4,
                     border_radius: 160,
+                    border_width: 0.0,
                     exclusive_zone: false,
                     autohide: Some(crate::AutoHide {
                         wait_time: 500,

--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -329,6 +329,7 @@ pub struct CosmicPanelConfig {
     /// space between panel plugins
     pub spacing: u32,
     pub border_radius: u32,
+    pub border_width: f32,
     // TODO autohide & exclusive zone should not be able to both be enabled at once
     /// exclusive zone
     pub exclusive_zone: bool,
@@ -359,6 +360,7 @@ impl PartialEq for CosmicPanelConfig {
             && self.padding == other.padding
             && self.spacing == other.spacing
             && self.border_radius == other.border_radius
+            && self.border_width == other.border_width
             && self.exclusive_zone == other.exclusive_zone
             && self.autohide == other.autohide
             && self.margin == other.margin
@@ -388,6 +390,7 @@ impl Default for CosmicPanelConfig {
             exclusive_zone: true,
             autohide: None,
             border_radius: 8,
+            border_width: 0.0,
             margin: 4,
             opacity: 0.8,
         }


### PR DESCRIPTION
This commit adds a new property to the panel config, which allows users to specify a border for the panel.

The default is 0.0, and we don't expose this property in cosmic-settings.

Design approval pending :)

Example of a border_width of 1.0:

![screenshot-2024-11-02-05-36-50](https://github.com/user-attachments/assets/1eac26a7-5bd7-42b9-87bc-4b1166dc5f71)
