### PR TITLE
refactor: throttle frame events and increase timeouts in general

### DIFF
--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -799,6 +799,7 @@ impl PanelSpace {
         _dh: &DisplayHandle,
         popup_manager: &mut PopupManager,
         time: u32,
+        throttle: Option<Duration>,
         mut renderer: Option<&mut GlesRenderer>,
         qh: &QueueHandle<GlobalState>,
     ) -> Instant {
@@ -878,7 +879,7 @@ impl PanelSpace {
             self.handle_overflow_popup_events();
 
             if prev == self.popups.len() && should_render {
-                if let Err(e) = self.render(renderer, time, qh) {
+                if let Err(e) = self.render(renderer, time, throttle, qh) {
                     error!("Failed to render, error: {:?}", e);
                 }
             }

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -104,6 +104,7 @@ impl PanelSpace {
         &mut self,
         renderer: &mut GlesRenderer,
         time: u32,
+        throttle: Option<Duration>,
         qh: &QueueHandle<GlobalState>,
     ) -> anyhow::Result<()> {
         if self.space_event.get().is_some()
@@ -271,9 +272,12 @@ impl PanelSpace {
                     }
                 }) {
                     let output = *o;
-                    window.send_frame(o, Duration::from_millis(time as u64), None, move |_, _| {
-                        Some(output.clone())
-                    });
+                    window.send_frame(
+                        o,
+                        Duration::from_millis(time as u64),
+                        throttle,
+                        move |_, _| Some(output.clone()),
+                    );
                 }
                 let wl_surface = self.layer.as_ref().unwrap().wl_surface().clone();
                 wl_surface.frame(qh, wl_surface.clone());

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -5,7 +5,7 @@ use std::{
     os::{fd::OwnedFd, unix::prelude::AsRawFd},
     rc::Rc,
     sync::{Arc, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use crate::{
@@ -1405,6 +1405,7 @@ impl WrapperSpace for PanelSpace {
         _qh: &QueueHandle<GlobalState>,
         _popup_manager: &mut PopupManager,
         _time: u32,
+        _throttle: Option<Duration>,
     ) -> Instant {
         unimplemented!()
     }

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -1,4 +1,8 @@
-use std::{cell::RefCell, rc::Rc, time::Instant};
+use std::{
+    cell::RefCell,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use crate::{
     iced::elements::target::SpaceTarget,
@@ -395,12 +399,13 @@ impl WrapperSpace for SpaceContainer {
         qh: &QueueHandle<GlobalState>,
         popup_manager: &mut PopupManager,
         time: u32,
+        throttle: Option<Duration>,
     ) -> std::time::Instant {
         self.space_list
             .iter_mut()
             .fold(None, |mut acc, s| {
                 let last_dirtied =
-                    s.handle_events(dh, popup_manager, time, self.renderer.as_mut(), qh);
+                    s.handle_events(dh, popup_manager, time, throttle, self.renderer.as_mut(), qh);
                 if let Some(last_dirty) = acc {
                     if last_dirty < last_dirtied {
                         acc = Some(last_dirtied);

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -131,9 +131,9 @@ pub fn run(
 
         // dispatch desktop client events
         let dur = if matches!(global_state.space.visibility(), Visibility::Hidden) {
-            Duration::from_millis(100)
+            Some(Duration::from_millis(500))
         } else {
-            Duration::from_millis(16)
+            Some(Duration::from_millis(16))
         };
 
         event_loop.dispatch(dur, &mut global_state)?;
@@ -147,6 +147,7 @@ pub fn run(
                 &global_state.client_state.queue_handle,
                 &mut global_state.server_state.popup_manager,
                 global_state.start_time.elapsed().as_millis().try_into()?,
+                dur,
             );
         }
         global_state.draw_dnd_icon();

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -221,6 +221,7 @@ pub trait WrapperSpace {
         qh: &QueueHandle<GlobalState>,
         popup_manager: &mut PopupManager,
         time: u32,
+        throttle: Option<Duration>,
     ) -> Instant;
 
     /// gets the config


### PR DESCRIPTION
This change should significantly lower CPU usage when idle. It could be refined a bit more in the future to also throttle non-hovered applets when the panel is hovered.