### PR TITLE
Pass `modifiers` and `group` from parent compositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2336,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3642,7 +3642,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smithay"
 version = "0.3.0"
-source = "git+https://github.com/smithay/smithay?rev=df79eeb#df79eeba63a8e9c2d33b9be2418aee6a940135e7"
+source = "git+https://github.com/ids1024/smithay?branch=update_mask#57aaf6e80b10f7153dd2313cc11e70452187be9d"
 dependencies = [
  "appendlist",
  "bitflags 2.6.0",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "smithay-client-toolkit"
 version = "0.19.2"
-source = "git+https://github.com/Smithay/client-toolkit//#618a876400cb6c6b07a8ac5d3557f404602ec077"
+source = "git+https://github.com/ids1024/client-toolkit//?branch=raw_modifiers#45963e8b5a7f6751adc0568bf378b3742a82133e"
 dependencies = [
  "bitflags 2.6.0",
  "bytemuck",
@@ -4735,7 +4735,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/c
 ] }
 
 [patch."https://github.com/Smithay/client-toolkit"]
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit//", features = [
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/ids1024/client-toolkit//", branch = "raw_modifiers", features = [
     "calloop",
     "xkbcommon",
 ] }
 [patch."crates-io"]
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit//", features = [
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/ids1024/client-toolkit//", branch = "raw_modifiers", features = [
     "calloop",
     "xkbcommon",
 ] }

--- a/cosmic-panel-bin/Cargo.toml
+++ b/cosmic-panel-bin/Cargo.toml
@@ -11,13 +11,13 @@ path = "src/main.rs"
 [dependencies]
 calloop = { version = "0.14.0", features = ["executor"] }
 ordered-float = "4.2.0"
-smithay = { git = "https://github.com/smithay/smithay", default-features = false, features = [
+smithay = { default-features = false, features = [
     "use_system_lib",
     "desktop",
     "backend_egl",
     "backend_drm",
     "renderer_gl",
-], rev = "df79eeb" }
+], git = "https://github.com/ids1024/smithay", branch = "update_mask" }
 # sctk = { git = "https://github.com/smithay/client-toolkit", package = "smithay-client-toolkit", features = ["calloop", "xkbcommon"] }
 sctk.workspace = true
 # sctk = { package = "smithay-client-toolkit", path = "../../fork/client-toolkit", default-features = false, features = ["calloop", "xkbcommon"] }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/seat.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/seat.rs
@@ -62,7 +62,8 @@ impl SeatHandler for GlobalState {
             // So instead of doing the right thing (and initialize these capabilities as
             // matching devices appear), we have to surrender to reality and
             // just always expose a keyboard and pointer.
-            new_server_seat.add_keyboard(Default::default(), 200, 20).unwrap();
+            let keyboard = new_server_seat.add_keyboard(Default::default(), 200, 20).unwrap();
+            keyboard.set_update_key(false);
             new_server_seat.add_pointer();
 
             let data_device = self.client_state.data_device_manager.get_data_device(qh, &seat);
@@ -147,7 +148,8 @@ impl SeatHandler for GlobalState {
         match capability {
             sctk::seat::Capability::Keyboard => {
                 if info.has_keyboard {
-                    sp.server.seat.add_keyboard(Default::default(), 200, 20).unwrap();
+                    let keyboard = sp.server.seat.add_keyboard(Default::default(), 200, 20).unwrap();
+                    keyboard.set_update_key(false);
                     if let Ok(kbd) = self.client_state.seat_state.get_keyboard(qh, &seat, None) {
                         sp.client.kbd.replace(kbd);
                     }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/mod.rs
@@ -234,7 +234,7 @@ impl ClientDndGrabHandler for GlobalState {
         seat.server.dnd_icon = icon;
     }
 
-    fn dropped(&mut self, seat: Seat<Self>) {
+    fn dropped(&mut self, _target: Option<WlSurface>, _validated: bool, seat: Seat<Self>) {
         let seat = match self.server_state.seats.iter_mut().find(|s| s.server.seat == seat) {
             Some(s) => s,
             None => return,


### PR DESCRIPTION
This fixes the behavior of keyboard input when modifiers are active when the panel receives input. It also makes keyboard input in the panel use the active `group` of the parent compositor, instead of the first one.

Requires https://github.com/Smithay/client-toolkit/pull/474 and https://github.com/Smithay/smithay/pull/1597.