### PR TITLE
Update Cargo.toml and remove extra slash from github url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/c
 ] }
 
 [patch."https://github.com/Smithay/client-toolkit"]
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay//client-toolkit/", rev = "4cf0def" }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit/", rev = "4cf0def" }
 
 [patch."crates-io"]
-sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay//client-toolkit/", rev = "4cf0def" }
+sctk = { package = "smithay-client-toolkit", git = "https://github.com/Smithay/client-toolkit/", rev = "4cf0def" }
 
 
 # [patch."https://github.com/pop-os/xdg-shell-wrapper"]


### PR DESCRIPTION
there was a double slash // in the github url, I removed the extra one