### PR TITLE
Remove use of deprecated `from_loc_and_size`, and use just `ToplevelInfo` instead of tuple

### DIFF
--- a/cosmic-panel-bin/src/iced/elements/background.rs
+++ b/cosmic-panel-bin/src/iced/elements/background.rs
@@ -2,7 +2,7 @@
 
 use calloop::LoopHandle;
 use cosmic::{
-    iced::{id, Color, Length, Radius},
+    iced::{id, Color, Length},
     iced_core::Shadow,
     theme,
     widget::horizontal_space,
@@ -59,7 +59,7 @@ impl Program for Background {
     fn view(&self) -> Element<'_, ()> {
         let width = self.logical_width as f32;
         let height = self.logical_height as f32;
-        let radius_arr: [f32; 4] = self.radius.clone();
+        let radius_arr: [f32; 4] = self.radius;
 
         let color = self.color;
         Element::from(

--- a/cosmic-panel-bin/src/iced/mod.rs
+++ b/cosmic-panel-bin/src/iced/mod.rs
@@ -16,7 +16,7 @@ use cosmic::{
         keyboard::{Event as KeyboardEvent, Modifiers as IcedModifiers},
         mouse::{Button as MouseButton, Cursor, Event as MouseEvent, ScrollDelta},
         window::Event as WindowEvent,
-        Limits, Point as IcedPoint, Rectangle as IcedRectangle, Size as IcedSize, Task,
+        Limits, Point as IcedPoint, Size as IcedSize, Task,
     },
     iced_core::{clipboard::Null as NullClipboard, renderer::Style, Color, Font, Length, Pixels},
     iced_renderer::Renderer as IcedRenderer,
@@ -28,10 +28,7 @@ use cosmic::{
     widget::Id,
     Theme,
 };
-use iced_tiny_skia::{
-    graphics::{damage, Viewport},
-    Primitive,
-};
+use iced_tiny_skia::graphics::Viewport;
 use once_cell::sync::Lazy;
 use ordered_float::OrderedFloat;
 use smithay::{
@@ -803,7 +800,7 @@ where
             if let Ok(buffer) = MemoryRenderBufferRenderElement::from_buffer(
                 renderer,
                 location.to_f64(),
-                &buffer,
+                buffer,
                 Some(alpha),
                 Some(Rectangle::new(
                     (0., 0.).into(),

--- a/cosmic-panel-bin/src/iced/mod.rs
+++ b/cosmic-panel-bin/src/iced/mod.rs
@@ -430,7 +430,7 @@ impl<P: Program + Send + 'static> PointerTarget<GlobalState> for IcedElement<P> 
 
     fn motion(&self, _seat: &Seat<GlobalState>, _data: &mut GlobalState, event: &MotionEvent) {
         let mut internal = self.0.lock().unwrap();
-        let bbox = Rectangle::from_loc_and_size((0, 0), internal.size);
+        let bbox = Rectangle::from_size(internal.size);
         if internal.request_redraws {
             internal.pending_update = Some(Instant::now());
         }

--- a/cosmic-panel-bin/src/main.rs
+++ b/cosmic-panel-bin/src/main.rs
@@ -12,7 +12,6 @@ use crate::xdg_shell_wrapper::{
 use anyhow::Result;
 use calloop::channel::Sender;
 use cctk::{
-    cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
     wayland_client::protocol::wl_output::WlOutput,
     wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1,
 };

--- a/cosmic-panel-bin/src/minimize.rs
+++ b/cosmic-panel-bin/src/minimize.rs
@@ -1,6 +1,5 @@
 use crate::xdg_shell_wrapper::shared_state::GlobalState;
 use cctk::{
-    cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
     wayland_client::{protocol::wl_surface::WlSurface, Proxy},
     wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1,
 };
@@ -36,7 +35,7 @@ pub fn update_toplevel(
     }) {
         toplevel_mngr.manager.set_rectangle(
             // If cosmic toplevel manager exists, cosmic toplevel info should too
-            &toplevel_info.cosmic_toplevel.as_ref().unwrap(),
+            toplevel_info.cosmic_toplevel.as_ref().unwrap(),
             &info.surface,
             info.rect.loc.x,
             info.rect.loc.y,
@@ -83,7 +82,7 @@ pub fn set_rectangles(state: &mut GlobalState, output: String, info: MinimizeApp
             }
             toplevel_mngr.manager.set_rectangle(
                 // If cosmic toplevel manager exists, cosmic toplevel info should too
-                &toplevel_info.cosmic_toplevel.as_ref().unwrap(),
+                toplevel_info.cosmic_toplevel.as_ref().unwrap(),
                 &info.surface,
                 info.rect.loc.x,
                 info.rect.loc.y,

--- a/cosmic-panel-bin/src/minimize.rs
+++ b/cosmic-panel-bin/src/minimize.rs
@@ -21,7 +21,8 @@ pub fn update_toplevel(
         return;
     };
     let minimized_applets = &state.space.minimized_applets;
-    let Some((_, toplevel_info)) = state.space.toplevels.iter().find(|t| &t.0 == &toplevel) else {
+    let Some(toplevel_info) = state.space.toplevels.iter().find(|t| t.foreign_toplevel == toplevel)
+    else {
         return;
     };
 
@@ -71,7 +72,7 @@ pub fn set_rectangles(state: &mut GlobalState, output: String, info: MinimizeApp
             return;
         };
 
-        for (toplevel, toplevel_info) in &mut state.space.toplevels {
+        for toplevel_info in &mut state.space.toplevels {
             if !toplevel_info.output.iter().any(|o| {
                 let Some(i) = state.client_state.output_state.info(o) else {
                     return false;

--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -267,10 +267,7 @@ impl PanelSpace {
             }
         }
 
-        let left = windows_left.iter().map(|e| {
-            let l = map_fn(e, anchor, Alignment::Left);
-            l
-        });
+        let left = windows_left.iter().map(|e| map_fn(e, anchor, Alignment::Left));
 
         let left_sum_scaled =
             left.clone().map(|(_, _, _, _, suggested_length)| suggested_length).sum::<i32>() as f64
@@ -700,16 +697,11 @@ impl PanelSpace {
 
             let border_radius = self.border_radius().min(w as u32).min(h as u32) as f32 / 2.;
             let radius = match (self.config.anchor, self.gap()) {
-                (PanelAnchor::Right, 0) => [border_radius as f32, 0., 0., border_radius as f32],
-                (PanelAnchor::Left, 0) => [0., border_radius as f32, border_radius as f32, 0.],
-                (PanelAnchor::Bottom, 0) => [border_radius as f32, border_radius as f32, 0., 0.],
-                (PanelAnchor::Top, 0) => [0., 0., border_radius as f32, border_radius as f32],
-                _ => [
-                    border_radius as f32,
-                    border_radius as f32,
-                    border_radius as f32,
-                    border_radius as f32,
-                ],
+                (PanelAnchor::Right, 0) => [border_radius, 0., 0., border_radius],
+                (PanelAnchor::Left, 0) => [0., border_radius, border_radius, 0.],
+                (PanelAnchor::Bottom, 0) => [border_radius, border_radius, 0., 0.],
+                (PanelAnchor::Top, 0) => [0., 0., border_radius, border_radius],
+                _ => [border_radius, border_radius, border_radius, border_radius],
             };
             let bg = background_element(
                 Id::new("panel_bg"),
@@ -1014,10 +1006,10 @@ impl PanelSpace {
                 .map(|s| s.to_f64())
                 .unwrap_or(size);
             if configured_size.w >= 1. {
-                size.w = size.w.min(configured_size.w as f64);
+                size.w = size.w.min(configured_size.w);
             }
             if configured_size.h >= 1. {
-                size.h = size.h.min(configured_size.h as f64);
+                size.h = size.h.min(configured_size.h);
             }
 
             let (major_dim, suggested_dim) = if self.config.is_horizontal() {

--- a/cosmic-panel-bin/src/space/overflow.rs
+++ b/cosmic-panel-bin/src/space/overflow.rs
@@ -147,9 +147,9 @@ impl PanelSpace {
             CosmicMappedInternal::OverflowButton(b) => b.with_program(|p| {
                 (&p.id == element_id).then_some((
                     e.clone(),
-                    if &self.left_overflow_button_id == &p.id {
+                    if self.left_overflow_button_id == p.id {
                         OverflowSection::Left
-                    } else if &self.right_overflow_button_id == &p.id {
+                    } else if self.right_overflow_button_id == p.id {
                         OverflowSection::Right
                     } else {
                         OverflowSection::Center

--- a/cosmic-panel-bin/src/space/overflow.rs
+++ b/cosmic-panel-bin/src/space/overflow.rs
@@ -121,9 +121,9 @@ impl PanelSpace {
                 c_popup,
                 egl_surface: None,
                 dirty: false,
-                rectangle: Rectangle::from_loc_and_size((0, 0), popup_bbox.size),
+                rectangle: Rectangle::from_size(popup_bbox.size),
                 state: Some(WrapperPopupState::WaitConfigure),
-                wrapper_rectangle: Rectangle::from_loc_and_size((0, 0), popup_bbox.size),
+                wrapper_rectangle: Rectangle::from_size(popup_bbox.size),
                 positioner,
                 has_frame: true,
                 fractional_scale,
@@ -177,7 +177,7 @@ impl PanelSpace {
             .filter_map(|(mut p, section)| {
                 if let Some(WrapperPopupState::Rectangle { width, height, x, y }) = p.state {
                     p.dirty = true;
-                    p.rectangle = Rectangle::from_loc_and_size((x, y), (width, height));
+                    p.rectangle = Rectangle::new((x, y).into(), (width, height).into());
                     let scaled_size: Size<i32, _> =
                         p.rectangle.size.to_f64().to_physical(p.scale).to_i32_round();
 

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use cctk::{
     cosmic_protocols::overlap_notify::v1::client::zcosmic_overlap_notification_v1::ZcosmicOverlapNotificationV1,
-    wayland_client::{protocol::wl_subcompositor::WlSubcompositor, Connection},
+    wayland_client::Connection,
 };
 
 use cosmic::iced::id;
@@ -48,7 +48,7 @@ use sctk::{
         xdg::XdgPositioner,
         WaylandSurface,
     },
-    subcompositor::{SubcompositorState, SubsurfaceData},
+    subcompositor::SubcompositorState,
 };
 use smithay::{
     backend::{
@@ -69,7 +69,7 @@ use smithay::{
     },
     utils::{Logical, Rectangle, Serial, Size},
     wayland::{
-        compositor::{with_states, SurfaceAttributes},
+        compositor::with_states,
         fractional_scale::with_fractional_scale,
         seat::WaylandFocus,
         shell::xdg::{PopupSurface, PositionerState},
@@ -500,7 +500,7 @@ impl PanelSpace {
                     if surface.is_alive()
                         && (self.layer.as_ref().is_some_and(|s| *s.wl_surface() == *surface)
                             || self.popups.iter().any(|p| {
-                                &p.popup.c_popup.wl_surface() == &surface
+                                p.popup.c_popup.wl_surface() == surface
                                     || self
                                         .popups
                                         .iter()
@@ -1005,7 +1005,7 @@ impl PanelSpace {
                             renderer
                         } else {
                             unsafe {
-                                let mut capabilities =
+                                let capabilities =
                                     GlesRenderer::supported_capabilities(&egl_context)
                                         .expect("Failed to query EGL Context");
                                 // capabilities.retain(|cap| *cap != Capability::);
@@ -1470,7 +1470,7 @@ impl PanelSpace {
         self.is_dirty = true;
         self.space.refresh();
 
-        let mut s_bbox = bbox_from_surface_tree(&wlsurface, (0, 0));
+        let mut s_bbox = bbox_from_surface_tree(wlsurface, (0, 0));
         s_bbox.size.w += 20;
         if let Some(s) = self.subsurfaces.iter_mut().find(|s| s.s_surface == *wlsurface) {
             let Some(offset) = self.space.element_location(&s.parent) else {
@@ -1507,13 +1507,13 @@ impl PanelSpace {
                 return;
             };
 
-            let Some(offset) = self.space.element_location(&parent_id) else {
+            let Some(offset) = self.space.element_location(parent_id) else {
                 return;
             };
             // create and insert subsurface
             // let new_surface = self
             let (c_subsurface, c_surface) =
-                wl_subcompositor.create_subsurface(ls.wl_surface().clone(), &qh);
+                wl_subcompositor.create_subsurface(ls.wl_surface().clone(), qh);
             let fractional_scale =
                 fractional_scale_manager.map(|f| f.fractional_scaling(&c_surface, qh));
 

--- a/cosmic-panel-bin/src/space/popup.rs
+++ b/cosmic-panel-bin/src/space/popup.rs
@@ -80,7 +80,7 @@ impl PanelSpace {
                 config.height = p.wrapper_rectangle.size.h;
             }
             let (width, height) = (config.width, config.height);
-            let new_rect = Rectangle::from_loc_and_size(config.position, (width, height));
+            let new_rect = Rectangle::new(config.position.into(), (width, height).into());
             if p.wrapper_rectangle != new_rect {
                 p.wrapper_rectangle = new_rect;
 
@@ -150,7 +150,7 @@ impl PanelSpace {
                 config.height = p.wrapper_rectangle.size.h;
             }
             let (width, height) = (config.width, config.height);
-            p.wrapper_rectangle = Rectangle::from_loc_and_size(config.position, (width, height));
+            p.wrapper_rectangle = Rectangle::new(config.position.into(), (width, height).into());
 
             p.state = match p.state {
                 None | Some(WrapperPopupState::WaitConfigure) => None,

--- a/cosmic-panel-bin/src/space/popup.rs
+++ b/cosmic-panel-bin/src/space/popup.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use crate::xdg_shell_wrapper::space::{ClientEglSurface, PanelPopup, WrapperPopupState};
 use cctk::wayland_client::Proxy;
 use sctk::shell::xdg::popup::{self};
@@ -30,7 +28,7 @@ impl PanelSpace {
             ));
             false
         });
-        if self.overflow_popup.as_ref().is_some_and(|(p, _)| !exclude(&p)) {
+        if self.overflow_popup.as_ref().is_some_and(|(p, _)| !exclude(p)) {
             let (popup, _) = self.overflow_popup.take().unwrap();
             tracing::info!("Closing overflow popup: {:?}", popup.c_popup.wl_surface());
             to_destroy.push((
@@ -41,8 +39,8 @@ impl PanelSpace {
         }
 
         for (popup, surface, s_surface) in to_destroy {
-            self.c_focused_surface.borrow_mut().retain(|s| &s.0 != &surface);
-            self.c_hovered_surface.borrow_mut().retain(|s| &s.0 != &surface);
+            self.c_focused_surface.borrow_mut().retain(|s| s.0 != surface);
+            self.c_hovered_surface.borrow_mut().retain(|s| s.0 != surface);
 
             if let Some(s_surface) = s_surface {
                 self.s_focused_surface

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -188,7 +188,7 @@ impl PanelSpace {
                     .then(|| {
                         PanelRenderElement::RoundedRectangle(RoundedRectangleShader::element(
                             renderer,
-                            Rectangle::from_loc_and_size((0, 0), dim.to_logical(1)),
+                            Rectangle::from_size(dim.to_logical(1)),
                             self.panel_rect_settings,
                         ))
                     })
@@ -222,7 +222,7 @@ impl PanelSpace {
 
                                 w.toplevel().map(|t| {
                                     let configured_size = t.current_state().size.map(|s| {
-                                        let mut r = Rectangle::from_loc_and_size(
+                                        let mut r = Rectangle::new(
                                             self.space
                                                 .element_location(w)
                                                 .unwrap_or_default()

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -462,7 +462,7 @@ impl PanelSpace {
 
                         let configured_size = t.current_state().size.map(|s| {
                             let mut r = Rectangle::new(
-                                loc.into(),
+                                loc,
                                 s.to_f64().to_physical_precise_round(self.scale),
                             );
                             if r.size.w == 0 {

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -267,10 +267,10 @@ impl WrapperSpace for PanelSpace {
                 c_popup,
                 egl_surface: None,
                 dirty: false,
-                rectangle: Rectangle::from_loc_and_size((0, 0), positioner_state.rect_size),
+                rectangle: Rectangle::from_size(positioner_state.rect_size),
                 state: cur_popup_state,
                 input_region: Some(input_region),
-                wrapper_rectangle: Rectangle::from_loc_and_size((0, 0), positioner_state.rect_size),
+                wrapper_rectangle: Rectangle::from_size(positioner_state.rect_size),
                 positioner,
                 has_frame: true,
                 fractional_scale,
@@ -294,7 +294,7 @@ impl WrapperSpace for PanelSpace {
         token: u32,
     ) -> anyhow::Result<()> {
         popup.with_pending_state(|pending| {
-            pending.geometry = Rectangle::from_loc_and_size((0, 0), pos_state.rect_size);
+            pending.geometry = Rectangle::from_size(pos_state.rect_size);
         });
         if let Some(i) = self.popups.iter().position(|wp| &wp.s_surface == &popup) {
             let p = &self.popups[i];
@@ -886,7 +886,7 @@ impl WrapperSpace for PanelSpace {
                         size.h = size.h.min(configured_size.h as f64);
                     }
                 }
-                let bbox = Rectangle::from_loc_and_size(location.to_f64(), size);
+                let bbox = Rectangle::new(location.to_f64(), size);
                 if bbox.contains((x as f64, y as f64)) {
                     SpaceTarget::try_from(e.clone()).ok().map(|s| (e.clone(), location, s))
                 } else {

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -16,10 +16,8 @@ use crate::{
     PanelCalloopMsg,
 };
 use cctk::{
-    cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
     toplevel_info::ToplevelInfo,
     wayland_client::protocol::wl_seat::WlSeat,
-    wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
     workspace::{Workspace, WorkspaceGroup},
 };
 use cosmic::{cosmic_config::CosmicConfigEntry, iced::id, theme};
@@ -493,7 +491,7 @@ impl SpaceContainer {
             .iter_mut()
             .filter(|s| {
                 s.output.as_ref().is_some_and(|o| o.1.name().as_str() == output_id)
-                    && &s.config.anchor == &anchor
+                    && s.config.anchor == anchor
             })
             .collect::<Vec<_>>();
 

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -61,8 +61,8 @@ pub struct SpaceContainer {
     pub panel_tx: calloop::channel::Sender<PanelCalloopMsg>,
     pub(crate) outputs: Vec<(WlOutput, Output, OutputInfo)>,
     pub(crate) watchers: HashMap<String, RecommendedWatcher>,
-    pub(crate) maximized_toplevels: Vec<(ExtForeignToplevelHandleV1, ToplevelInfo)>,
-    pub(crate) toplevels: Vec<(ExtForeignToplevelHandleV1, ToplevelInfo)>,
+    pub(crate) maximized_toplevels: Vec<ToplevelInfo>,
+    pub(crate) toplevels: Vec<ToplevelInfo>,
     pub(crate) workspace_groups: Vec<WorkspaceGroup>,
     pub(crate) workspaces: Vec<Workspace>,
     pub(crate) is_dark: bool,
@@ -401,7 +401,7 @@ impl SpaceContainer {
         let maximized_outputs = self.maximized_outputs();
         for (wl_output, output, info) in outputs {
             let output_name = output.name();
-            let has_toplevel = self.toplevels.iter().any(|(_, t)| t.output.contains(wl_output));
+            let has_toplevel = self.toplevels.iter().any(|t| t.output.contains(wl_output));
             if force_output.as_ref() != Some(wl_output) && force_output.is_some() {
                 continue;
             }

--- a/cosmic-panel-bin/src/space_container/toplevel.rs
+++ b/cosmic-panel-bin/src/space_container/toplevel.rs
@@ -1,7 +1,7 @@
 use cctk::{
     cosmic_protocols::{
         toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
-        toplevel_management::v1::client::zcosmic_toplevel_manager_v1, workspace,
+        toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
     },
     toplevel_info::ToplevelInfo,
     wayland_client::{protocol::wl_output::WlOutput, Connection},

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -17,7 +17,7 @@ use crate::{
         wp_viewporter::ViewporterState,
     },
 };
-use cctk::{cosmic_protocols::overlap_notify, wayland_client::protocol::wl_pointer::WlPointer};
+use cctk::wayland_client::protocol::wl_pointer::WlPointer;
 use cosmic_panel_config::{CosmicPanelBackground, CosmicPanelContainerConfig, CosmicPanelOuput};
 use itertools::Itertools;
 use sctk::{
@@ -27,7 +27,6 @@ use sctk::{
         protocol::{wl_output::WlOutput, wl_surface as c_wl_surface},
         Connection, QueueHandle,
     },
-    seat::pointer::PointerEvent,
     shell::{
         wlr_layer::{LayerShell, LayerSurface, LayerSurfaceConfigure},
         WaylandSurface,

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/data_device/data_source.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/data_device/data_source.rs
@@ -55,7 +55,7 @@ impl DataSourceHandler for GlobalState {
             if let Some(dnd_source) = seat.server.dnd_source.as_ref() {
                 dnd_source.send(mime, fd.as_fd());
             }
-        } else if let Some(_) = seat.server.selection_source.as_ref() {
+        } else if seat.server.selection_source.as_ref().is_some() {
             _ = request_data_device_client_selection(&seat.server.seat, mime, fd.into());
         }
     }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/pointer.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/pointer.rs
@@ -233,7 +233,7 @@ impl GlobalState {
                             (surface_x as i32, surface_y as i32),
                             &seat_name,
                             c_focused_surface,
-                            &pointer,
+                            pointer,
                         )
                     {
                         if let Some(ev) = surface.wl_surface().and_then(|s| {

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/seat.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/seat.rs
@@ -27,27 +27,22 @@ impl SeatHandler for GlobalState {
                 .new_wl_seat(&self.server_state.display_handle, name.clone());
 
             let kbd = if info.has_keyboard {
-                if let Ok(kbd) = self.client_state.seat_state.get_keyboard(qh, &seat, None) {
-                    Some(kbd)
-                } else {
-                    None
-                }
+                self.client_state.seat_state.get_keyboard(qh, &seat, None).ok()
             } else {
                 None
             };
 
             let ptr = if info.has_pointer {
-                if let Ok(ptr) = self.client_state.seat_state.get_pointer_with_theme(
-                    qh,
-                    &seat,
-                    self.client_state.shm_state.wl_shm(),
-                    self.client_state.compositor_state.create_surface(qh),
-                    ThemeSpec::System,
-                ) {
-                    Some(ptr)
-                } else {
-                    None
-                }
+                self.client_state
+                    .seat_state
+                    .get_pointer_with_theme(
+                        qh,
+                        &seat,
+                        self.client_state.shm_state.wl_shm(),
+                        self.client_state.compositor_state.create_surface(qh),
+                        ThemeSpec::System,
+                    )
+                    .ok()
             } else {
                 None
             };

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/toplevel.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/toplevel.rs
@@ -53,7 +53,7 @@ impl ToplevelInfoHandler for GlobalState {
         } else {
             return;
         };
-        self.space.new_toplevel(_conn, toplevel, info);
+        self.space.new_toplevel(_conn, info);
     }
 
     fn update_toplevel(
@@ -72,7 +72,7 @@ impl ToplevelInfoHandler for GlobalState {
         } else {
             return;
         };
-        self.space.update_toplevel(_conn, toplevel, info);
+        self.space.update_toplevel(_conn, info);
     }
 
     fn toplevel_closed(

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/toplevel.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/handlers/toplevel.rs
@@ -1,8 +1,5 @@
 use cctk::{
-    cosmic_protocols::{
-        toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
-        toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
-    },
+    cosmic_protocols::toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
     toplevel_info::{ToplevelInfoHandler, ToplevelInfoState},
     toplevel_management::ToplevelManagerHandler,
     wayland_client::{self, WEnum},

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/client/state.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/client/state.rs
@@ -5,9 +5,8 @@ use crate::{
     },
 };
 use cctk::{
-    cosmic_protocols::overlap_notify, toplevel_info::ToplevelInfoState,
-    toplevel_management::ToplevelManagerState, wayland_client::protocol::wl_pointer::WlPointer,
-    workspace::WorkspaceState,
+    toplevel_info::ToplevelInfoState, toplevel_management::ToplevelManagerState,
+    wayland_client::protocol::wl_pointer::WlPointer, workspace::WorkspaceState,
 };
 use sctk::{
     compositor::CompositorState,

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -6,13 +6,8 @@
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use sctk::{reexports::client::Proxy, shm::multi::MultiPool};
-use smithay::{
-    backend::input::KeyState,
-    input::keyboard::FilterResult,
-    reexports::{calloop, wayland_server::Display},
-    utils::SERIAL_COUNTER,
-};
+use sctk::shm::multi::MultiPool;
+use smithay::reexports::{calloop, wayland_server::Display};
 
 use client::state::ClientState;
 pub use client::{
@@ -90,7 +85,7 @@ pub fn run(
         .expect("Failed to insert cleanup timer.");
     global_state.bind_display(&s_dh);
 
-    let mut last_cleanup = Instant::now();
+    let last_cleanup = Instant::now();
     let five_min = Duration::from_secs(300);
 
     // TODO find better place for this

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/compositor.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/compositor.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use sctk::{
     reexports::client::Proxy,
     shell::{
@@ -15,7 +13,7 @@ use smithay::{
     delegate_compositor, delegate_shm,
     desktop::{utils::bbox_from_surface_tree, LayerSurface as SmithayLayerSurface},
     reexports::wayland_server::protocol::{wl_buffer, wl_surface::WlSurface},
-    utils::{Logical, Size, Transform},
+    utils::Transform,
     wayland::{
         buffer::BufferHandler,
         compositor::{get_role, CompositorHandler, CompositorState},

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/popup.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/popup.rs
@@ -93,7 +93,7 @@ impl WrapperPopup {
     ) -> bool {
         if let Some(WrapperPopupState::Rectangle { width, height, x, y }) = self.popup.state {
             self.popup.dirty = true;
-            self.popup.rectangle = Rectangle::from_loc_and_size((x, y), (width, height));
+            self.popup.rectangle = Rectangle::new((x, y).into(), (width, height).into());
             let scaled_size: Size<i32, _> =
                 self.popup.rectangle.size.to_f64().to_physical(self.popup.scale).to_i32_round();
             if let Some(s) = self.popup.egl_surface.as_mut() {

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -14,7 +14,6 @@ use sctk::{
         protocol::{wl_output as c_wl_output, wl_surface},
         Connection, QueueHandle,
     },
-    seat::pointer::PointerEvent,
     shell::{
         wlr_layer::{LayerShell, LayerSurface, LayerSurfaceConfigure},
         xdg::{XdgPositioner, XdgShell},

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/toplevel.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/toplevel.rs
@@ -22,20 +22,10 @@ pub trait ToplevelManagerSpace {
 /// handle events related to toplevels
 pub trait ToplevelInfoSpace {
     /// A new toplevel was created
-    fn new_toplevel(
-        &mut self,
-        _conn: &Connection,
-        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
-        info: &ToplevelInfo,
-    );
+    fn new_toplevel(&mut self, _conn: &Connection, info: &ToplevelInfo);
 
     /// A toplevel was updated
-    fn update_toplevel(
-        &mut self,
-        _conn: &Connection,
-        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
-        info: &ToplevelInfo,
-    );
+    fn update_toplevel(&mut self, _conn: &Connection, info: &ToplevelInfo);
 
     /// A toplevel was closed
     fn toplevel_closed(

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/toplevel.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/toplevel.rs
@@ -1,10 +1,6 @@
 use cctk::{
-    cosmic_protocols::{
-        toplevel_info::v1::client::zcosmic_toplevel_handle_v1,
-        toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
-    },
-    toplevel_info::ToplevelInfo,
-    wayland_client::Connection,
+    cosmic_protocols::toplevel_management::v1::client::zcosmic_toplevel_manager_v1,
+    toplevel_info::ToplevelInfo, wayland_client::Connection,
     wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1,
 };
 use wayland_backend::protocol::WEnum;

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/workspace.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/workspace.rs
@@ -1,5 +1,3 @@
-use cctk::workspace::WorkspaceGroup;
-
 pub trait WorkspaceHandlerSpace {
     /// A workspace was updated
     fn update<'a>(


### PR DESCRIPTION
A couple updates for changes in Smithay and cctk.

Also ran `cargo clippy --fix`, which helps to clean up some things.