### PR TITLE
Add "Custom" panel size, with an arbitrary value for the size

### DIFF
--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -146,7 +146,10 @@ impl PanelSize {
                 PanelSize::M => 28,
                 PanelSize::L => 32,
                 PanelSize::XL => 48,
-                PanelSize::Custom(s) => *s / 2,
+                PanelSize::Custom(s) => {
+                    let s = (*s).max(16) / 4 * 4;
+                    s / 2
+                },
             }
         } else {
             match self {
@@ -155,7 +158,10 @@ impl PanelSize {
                 PanelSize::M => 40,
                 PanelSize::L => 48,
                 PanelSize::XL => 56,
-                PanelSize::Custom(s) => *s * 7 / 10,
+                PanelSize::Custom(s) => {
+                    let s = (*s).max(16) / 4 * 4;
+                    s * 7 / 10
+                },
             }
         }
     }
@@ -168,7 +174,10 @@ impl PanelSize {
                 PanelSize::M => 14,
                 PanelSize::L => 16,
                 PanelSize::XL => 16,
-                PanelSize::Custom(s) => (*s / 4) as u16,
+                PanelSize::Custom(s) => {
+                    let s = (*s).max(16) / 4 * 4;
+                    (s / 4) as u16
+                },
             }
         } else {
             match self {
@@ -177,7 +186,10 @@ impl PanelSize {
                 PanelSize::M => 8,
                 PanelSize::L => 8,
                 PanelSize::XL => 12,
-                PanelSize::Custom(s) => (*s * 3 / 20) as u16,
+                PanelSize::Custom(s) => {
+                    let s = (*s).max(16) / 4 * 4;
+                    (s * 3 / 20) as u16
+                },
             }
         }
     }
@@ -616,7 +628,10 @@ impl CosmicPanelConfig {
             PanelSize::M => 8 + gap..101 + gap,
             PanelSize::L => 8 + gap..121 + gap,
             PanelSize::XL => 8 + gap..141 + gap,
-            PanelSize::Custom(s) => 8 + gap..s * 2 + 1 + gap,
+            PanelSize::Custom(s) => {
+                let s = (*s).max(16) / 4 * 4;
+                8 + gap..s * 2 + 1 + gap
+            },
         };
         assert!(2 * self.padding + gap < bar_thickness.end);
         let o_h = suggested_length.unwrap_or_else(|| output_dims.unwrap_or_default().1);


### PR DESCRIPTION
This commit adds a new panel size to the PanelSize enum that allows users to specify an arbitrary size for the panel. Since there are a few different calculated values for each hardcoded panel size (XS, S, M, L, XL), I came up with some math to decide the sizes of applet icons and padding based on a rough average of each of the panel sizes, to hopefully capture the best size for everything with a custom panel size.

For a custom panel size of n:

get_dimensions returns 8 + gap..2n + 1 + gap
get_applet_icon_size returns n/2 for symbolic icons, 7n/10 for regular icons get_applet_padding returns n/4 for symbolic icons, 3n/20 for regular icons get_applet_icon_size_with_padding returns n for symbolic and regular icons

This results in a relatively balanced applet size and padding for any custom size.

To specify a custom panel size, use Custom(x) where x is a number, in the panel size config.

Along with a cosmic-applets and libcosmic PR, a custom panel size of 48 looks like this:

![Screenshot_2025-05-23_20-18-20](https://github.com/user-attachments/assets/1bba87c6-df8f-4a32-9a23-5bf4c31e7c0b)

Here's a panel of size 100 looks like:

![Screenshot_2025-05-23_20-20-51](https://github.com/user-attachments/assets/3c1af5a8-272d-41f2-afdb-d5de48e16506)

And here's a panel of size 16:

![Screenshot_2025-05-23_20-22-03](https://github.com/user-attachments/assets/dbc9149e-ccd6-44ef-a7f5-d4f193b89234)


If you're curious, here's the panel size math I did:

| panel_size | get_dimensions()      | get_applet_icon_size()  | get_applet_padding()    | get_applet_icon_size_with_padding() | applet size percentage | icon_with_padding % of dimensions - 1 |
| ---------- | --------------------- | ----------------------- | ----------------------- | ----------------------------------- | ---------------------- | ------------------------------------- |
| XS         | 8 + gap..61 + gap     | 16  symbolic, 24    reg | 8   symbolic, 4     non | 32 symbolic, 32 non                 | 50% symbolic, 66% non  | 53%                                   |
| S          | 8 + gap..81 + gap     | 20  symbolic, 32    reg | 10  symbolic, 4     non | 40 symbolic, 40 non                 | 50% symbolic, 80% non  | 50%                                   |
| M          | 8 + gap..101 + gap    | 28  symbolic, 40    reg | 14  symbolic, 8     non | 56 symbolic, 56 non                 | 50% symbolic, 71% non  | 56%                                   |
| L          | 8 + gap..121 + gap    | 32  symbolic, 48    reg | 16  symbolic, 8     non | 64 symbolic, 64 non                 | 50% symbolic, 75% non  | 53%                                   |
| XL         | 8 + gap..141 + gap    | 48  symbolic, 56    reg | 16  symbolic, 12    non | 80 symbolic, 80 non                 | 66% symbolic, 70% non  | 57%                                   |
| Custom(n)  | 8 + gap..2n + 1 + gap | n/2 symbolic, 7n/10 reg | n/4 symbolic, 3n/20 non | n  symbolic, n  non                 | 50% symbolic, 70% non  | 50%                                   |