### PR TITLE
fix: handle minimized toplevels in intellihide

### DIFF
--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -782,9 +782,7 @@ impl WrapperSpace for SpaceContainer {
             .find(|s| s.layer.as_ref().map(|s| s.wl_surface()) == Some(layer.wl_surface()))
         {
             space.configure_panel_layer(layer, configure, &mut self.renderer);
-            if matches!(space.visibility(), Visibility::Visible)
-                || space.toplevel_overlaps.is_empty()
-            {
+            if matches!(space.visibility(), Visibility::Visible) || !space.has_toplevel_overlap() {
                 space.output.as_ref().map(|o| (o.1.name(), space.config.anchor));
             }
         }


### PR DESCRIPTION
Minimized toplevels still overlap, but can be tracked and filtered.