### PR TITLE
fix: increase timeout for notifications proxy

### DIFF
--- a/cosmic-panel-bin/src/main.rs
+++ b/cosmic-panel-bin/src/main.rs
@@ -201,7 +201,7 @@ fn main() -> Result<()> {
             let _ = process_manager.set_max_restarts(999999).await;
 
             let mut notifications_proxy =
-                match tokio::time::timeout(Duration::from_secs(1), notifications_conn()).await {
+                match tokio::time::timeout(Duration::from_secs(5), notifications_conn()).await {
                     Ok(Ok(p)) => Some(p),
                     err => {
                         error!("Failed to connect to the notifications daemon {:?}", err);


### PR DESCRIPTION
Fixes issue where the notifications applet doesn't start properly at startup due to a timeout when connecting to the daemon:

```sh
❯ journalctl -b0 /usr/bin/cosmic-panel
Jun 13 18:38:15 zuka cosmic-panel[3295]: Failed to connect to the notifications daemon Err(Elapsed(()))
Jun 13 18:38:15 zuka cosmic-panel[3295]: Failed to connect to the notifications daemon Ok(Err(File exists (os error 17)))
Jun 13 18:38:15 zuka cosmic-panel[3295]: Can't start notifications applet without a connection
[...]
```

I've noticed that this issue affects both my 7 year old laptop and my 1/2 year old desktop PC, and only happens in the first login after boot, so I think it's a race condition with the daemon, but also not related to hardware speed.
