### PR TITLE
fix(maximized): track sticky windows for each output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5217,7 +5217,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
with this, handling of maximized sticky windows should be better [ef5a1a3](https://github.com/pop-os/cosmic-comp/commit/ef5a1a3284f4dd695f9a003f8fa8e305a3d84562) 