### PR TITLE
fix: avoid input region rectangle accumulation

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -868,7 +868,6 @@ impl PanelSpace {
                         size.1 -= self.logical_layer_end_overlap - container_lengthwise_pos;
                     }
                 }
-
                 input_region.add(loc.0, loc.1, size.0, size.1);
             };
         }

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -1708,7 +1708,9 @@ impl PanelSpace {
         }
     }
 
-    pub fn cleanup(&mut self) {}
+    pub fn cleanup(&mut self, compositor_state: &sctk::compositor::CompositorState) {
+        self.input_region = Some(Region::new(compositor_state).unwrap());
+    }
 
     pub fn dirty_subsurface(
         &mut self,

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -136,10 +136,10 @@ impl PanelSpace {
                     anyhow::bail!("Failed to clear panel.");
                 };
 
-                _ = frame.clear(Color32F::new(0.0, 0.0, 0.0, 0.0), &[Rectangle::new(
-                    (0, 0).into(),
-                    dim,
-                )]);
+                _ = frame.clear(
+                    Color32F::new(0.0, 0.0, 0.0, 0.0),
+                    &[Rectangle::new((0, 0).into(), dim)],
+                );
                 if let Ok(sync_point) = frame.finish() {
                     if let Err(err) = sync_point.wait() {
                         tracing::error!("Error waiting for sync point: {:?}", err);
@@ -261,10 +261,10 @@ impl PanelSpace {
                     elements.extend(bg);
                 };
 
-                let res =
+                let _res =
                     my_renderer.render_output(renderer, &mut f, age, &elements, clear_color)?;
                 drop(f);
-                let mut dmg = res.damage.cloned();
+                // let mut dmg = res.damage.cloned();
 
                 egl_surface.swap_buffers(None)?;
 

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -545,9 +545,9 @@ impl SpaceContainer {
         }
     }
 
-    pub fn cleanup(&mut self) {
+    pub fn cleanup(&mut self, compositor_state: &sctk::compositor::CompositorState) {
         for space in &mut self.space_list {
-            space.cleanup();
+            space.cleanup(compositor_state);
         }
     }
 

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/shared_state.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/shared_state.rs
@@ -95,7 +95,7 @@ impl GlobalState {
                 move |_, _modifiers, _keysym| FilterResult::Forward,
             );
         }
-        self.space.cleanup();
+        self.space.cleanup(&self.client_state.compositor_state);
     }
 
     /// set the scale factor for a surface


### PR DESCRIPTION
it seems the compositor does not ever merge the input regions, and shrink the list, so over time they build up and cause issues on hover. This could fix #331 