### PR TITLE
fix: improve cleanup of fds

### DIFF
--- a/cosmic-panel-bin/src/main.rs
+++ b/cosmic-panel-bin/src/main.rs
@@ -203,8 +203,8 @@ fn main() -> Result<()> {
             let mut notifications_proxy =
                 match tokio::time::timeout(Duration::from_secs(5), notifications_conn()).await {
                     Ok(Ok(p)) => Some(p),
-                    err => {
-                        error!("Failed to connect to the notifications daemon {:?}", err);
+                    _ => {
+                        error!("Failed to connect to the notifications daemon.");
                         None
                     },
                 };
@@ -232,11 +232,8 @@ fn main() -> Result<()> {
                             .await
                             {
                                 Ok(Ok(p)) => Some(p),
-                                err => {
-                                    error!(
-                                        "Failed to connect to the notifications daemon {:?}",
-                                        err
-                                    );
+                                _ => {
+                                    error!("Failed to connect to the notifications daemon",);
                                     None
                                 },
                             };

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -579,10 +579,10 @@ impl WrapperSpace for PanelSpace {
                                 let privileged_socket = data.conn.lock().unwrap().take().unwrap();
                                 applet_env.push((
                                     "X_PRIVILEGED_WAYLAND_SOCKET".to_string(),
-                                    privileged_socket.as_raw_fd().to_string(),
+                                    privileged_socket.0.as_raw_fd().to_string(),
                                 ));
 
-                                fds.push(privileged_socket.into());
+                                fds.push(privileged_socket.0.into());
                                 panel_client.security_ctx = Some(security_context);
                             },
                             Err(why) => {
@@ -693,9 +693,9 @@ impl WrapperSpace for PanelSpace {
                                                 data.conn.lock().unwrap().take().unwrap();
                                             applet_env.push((
                                                 "X_PRIVILEGED_WAYLAND_SOCKET".to_string(),
-                                                privileged_socket.as_raw_fd().to_string(),
+                                                privileged_socket.0.as_raw_fd().to_string(),
                                             ));
-                                            fds.push(privileged_socket.into());
+                                            fds.push(privileged_socket.0.into());
                                         })
                                 },
                             )
@@ -720,10 +720,13 @@ impl WrapperSpace for PanelSpace {
                                     return;
                                 };
                                 if let Err(err) = pman
-                                    .update_process_env(&key, vec![(
-                                        "COSMIC_NOTIFICATIONS".to_string(),
-                                        fd.as_raw_fd().to_string(),
-                                    )])
+                                    .update_process_env(
+                                        &key,
+                                        vec![(
+                                            "COSMIC_NOTIFICATIONS".to_string(),
+                                            fd.as_raw_fd().to_string(),
+                                        )],
+                                    )
                                     .await
                                 {
                                     error!("Failed to update process env: {}", err);


### PR DESCRIPTION
I noticed that some file descriptors seemed to be leaking when making config changes, and this should resolve the issue.