### PR TITLE
delay for un-hide / show of panel with autohide

### DIFF
--- a/cosmic-panel-config/src/container_config.rs
+++ b/cosmic-panel-config/src/container_config.rs
@@ -194,6 +194,7 @@ impl Default for CosmicPanelContainerConfig {
                         wait_time: 500,
                         transition_time: 200,
                         handle_size: 2,
+                        unhide_delay: 200,
                     }),
                     margin: 0,
                     opacity: 1.0,

--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -267,11 +267,18 @@ pub struct AutoHide {
     /// size of the handle in pixels
     /// should be > 0
     pub handle_size: u32,
+    /// time in milliseconds before the panel should un-hide
+    #[serde(default = "_unhide_delay_default")]
+    pub unhide_delay: u32,
+}
+
+const fn _unhide_delay_default() -> u32 {
+    200
 }
 
 impl Default for AutoHide {
     fn default() -> Self {
-        Self { wait_time: 1000, transition_time: 200, handle_size: 4 }
+        Self { wait_time: 1000, transition_time: 200, handle_size: 4, unhide_delay: 200 }
     }
 }
 


### PR DESCRIPTION
Using COSMIC panel on a small screen laptop I have auto-hide enabled to maximize my screen real estate and using a "nub" pointer (or even a track pad) I often overshoot the top of the screen and cause the panel to un-hide unintentionally.

This feature just adds some delay or resistance before the panel un-hides, which works a lot better for this use case since I can overshoot and correct the position of the pointer without having to wait for the panel to hide in order to use the controls at the top of the window.

Mostly just looking for feedback/guidance on this, if there's appetite to get this merged I am happy to shepherd the change and get it into a state where it can be merged.

Corresponding PR for cosmic-settings: https://github.com/pop-os/cosmic-settings/pull/1400.