### PR TITLE
fix: issue with background rendering by changing scale

### DIFF
--- a/cosmic-panel-bin/src/iced/elements/background.rs
+++ b/cosmic-panel-bin/src/iced/elements/background.rs
@@ -26,6 +26,7 @@ pub fn background_element(
     panel_id: usize,
     logical_pos: [f32; 2],
     color: [f32; 4],
+    scale: f64,
 ) -> BackgroundElement {
     IcedElement::new(
         Background {
@@ -35,6 +36,7 @@ pub fn background_element(
             radius,
             logical_pos: (logical_pos[0].round() as i32, logical_pos[1].round() as i32),
             color,
+            scale,
         },
         (logical_width, logical_height),
         loop_handle,
@@ -51,6 +53,7 @@ pub struct Background {
     pub radius: [f32; 4],
     pub logical_pos: (i32, i32),
     pub color: [f32; 4],
+    pub scale: f64,
 }
 
 impl Program for Background {

--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -705,7 +705,10 @@ impl PanelSpace {
         };
         if !self.background_element.as_ref().is_some_and(|e| {
             e.with_program(|p| {
-                p.logical_height == h && p.logical_width == w && self.bg_color() == p.color
+                p.logical_height == h
+                    && p.logical_width == w
+                    && self.bg_color() == p.color
+                    && p.scale == self.scale
             })
         }) || self.animate_state.as_ref().is_some()
             || self.transitioning
@@ -783,6 +786,7 @@ impl PanelSpace {
                 self.space.id(),
                 loc,
                 self.bg_color(),
+                self.scale,
             );
             bg.output_enter(&output, Rectangle::default());
             self.background_element = Some(bg.clone());


### PR DESCRIPTION
### **Issue**

When using the panel in **docked mode** (with “Extend panel to screen edges” disabled), the panel’s background does not always re-render correctly after changing the **display scaling**.

This occurs because the background rendering logic does not check for changes in the display scale factor.

<img width="1312" height="467" alt="panel_dock_bg_issue" src="https://github.com/user-attachments/assets/989844b9-66b2-49f4-b796-b7207b816dcb" />

---

### **System Information**

* **Pop!_OS version:** 24.04 LTS (Beta / last release)
* **Setting:** “Extend panel to screen edges” — **disabled**

---

### **Root Cause**

The background struct does not account for scaling changes, causing stale rendering when the display scale factor updates.

---

### **Solution**

Add a `scale` variable to the background struct and re-render the background when the scale changes.
