### PR TITLE
fix: background overlap after spacer updates

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -712,6 +712,7 @@ impl PanelSpace {
             })
         }) || self.animate_state.as_ref().is_some()
             || self.transitioning
+            || self.is_background_dirty
         {
             self.transitioning = false;
             if let Some(bg) = self.background_element.take() {
@@ -795,6 +796,7 @@ impl PanelSpace {
                 (loc[0] as i32, loc[1] as i32),
                 false,
             );
+            self.is_background_dirty = false;
         }
         input_region.subtract(0, 0, i32::MAX, i32::MAX);
         let anim_gap = self.anchor_gap;

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -365,6 +365,7 @@ pub struct PanelSpace {
     pub overflow_popup: Option<(PanelPopup, OverflowSection)>,
     pub remap_attempts: u32,
     pub background_element: Option<BackgroundElement>,
+    pub is_background_dirty: bool,
     pub last_minimize_update: Instant,
     pub(crate) minimized_toplevels: HashSet<wayland_backend::client::ObjectId>,
     pub(crate) toplevel_overlaps: HashSet<wayland_backend::client::ObjectId>,
@@ -440,6 +441,7 @@ impl PanelSpace {
             overflow_popup: None,
             remap_attempts: 0,
             background_element: None,
+            is_background_dirty: false,
             last_minimize_update: Instant::now() - Duration::from_secs(1),
             anchor_gap: 0,
             notification_subscription: None,
@@ -485,6 +487,7 @@ impl PanelSpace {
 
     pub fn apply_layer_overlaps(&mut self) {
         self.is_dirty = true;
+        self.is_background_dirty = true;
         self.logical_layer_start_overlap = 0;
         self.logical_layer_end_overlap = 0;
         for rect in self.layer_overlaps.values() {


### PR DESCRIPTION
Fixes pop-os/cosmic-epoch#2379

### Issue
The `apply_layer_overlaps` fn in `panel_space.rs` was missing a background
update, causing visual overlap.
<img width="952" height="1012" alt="Screenshot_2025-11-07_11-15-29" src="https://github.com/user-attachments/assets/c1b4a766-a549-4c59-82a0-0d7f939760a5" />
(See bottom right in the screenshot, the minute part is overlapped by the background of the dock)

### Reproduction
Set workspace in floating mode with dock (bottom) and panel (right), both auto-hide enabled and extended to the edge.
Toggle dock auto-hide multiple times, you will see overlap when enabling it.

### Solution
Added an is_background_dirty flag to PanelSpace to trigger a background
update when needed.
