### PR TITLE
fix: offset of animation for autohide

### DIFF
--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -250,7 +250,7 @@ impl PanelSpace {
                         Point::from((
                             (pos.0 as f64 * self.scale) as i32,
                             (pos.1 as f64 * self.scale) as i32,
-                        )) + anim_gap_translation,
+                        )),
                         self.scale.into(),
                         1.0,
                     )


### PR DESCRIPTION
It is already applied in the layout step so it should be removed here.