### PR TITLE
fix: check overflow popup for focus tracking

### DIFF
--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -825,6 +825,10 @@ impl PanelSpace {
                                         .iter()
                                         .any(|p| p.popup.c_popup.wl_surface() == surface)
                             }))
+                        || self
+                            .overflow_popup
+                            .as_ref()
+                            .is_some_and(|(p, _)| p.c_popup.wl_surface() == surface)
                     {
                         match (&acc, &f) {
                             (FocusStatus::LastFocused(t_acc), FocusStatus::LastFocused(t_cur)) => {


### PR DESCRIPTION
this prevents autohide from hiding when the overflow menu is hovered.