### PR TITLE
fix: make dock corner radius respect system theme

### DIFF
--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -715,7 +715,9 @@ impl PanelSpace {
         if let Some(animatable_state) = self.animate_state.as_ref() {
             animatable_state.cur.border_radius
         } else {
-            self.config.border_radius
+            self.config
+                .border_radius
+                .unwrap_or(self.colors.theme.cosmic().corner_radius as u32)
         }
     }
 
@@ -1532,13 +1534,20 @@ impl PanelSpace {
         } else {
             let start = AnimatableState {
                 bg_color: self.colors.bg_color(self.config.opacity),
-                border_radius: self.config.border_radius,
+                border_radius: self
+                    .config
+                    .border_radius
+                    .unwrap_or(self.colors.theme.cosmic().corner_radius as u32),
                 expanded: if self.config.expand_to_edges { 1.0 } else { 0.0 },
                 gap: self.gap(),
             };
             let cur = start.clone();
             let mut end = start.clone();
             end.bg_color = color;
+            end.border_radius = self
+                .config
+                .border_radius
+                .unwrap_or(colors.theme.cosmic().corner_radius as u32);
             self.animate_state = Some(AnimateState {
                 start,
                 end,
@@ -1765,13 +1774,18 @@ impl PanelSpace {
         if animate {
             let start = AnimatableState {
                 bg_color: self.colors.bg_color(self.config.opacity),
-                border_radius: self.config.border_radius,
+                border_radius: self
+                    .config
+                    .border_radius
+                    .unwrap_or(self.colors.theme.cosmic().corner_radius as u32),
                 expanded: if self.config.expand_to_edges { 1.0 } else { 0.0 },
                 gap: self.gap(),
             };
             let end = AnimatableState {
                 bg_color,
-                border_radius: config.border_radius,
+                border_radius: config
+                    .border_radius
+                    .unwrap_or(self.colors.theme.cosmic().corner_radius as u32),
                 expanded: if config.expand_to_edges { 1.0 } else { 0.0 },
                 gap: config.get_effective_anchor_gap() as u16,
             };

--- a/cosmic-panel-config/config.ron
+++ b/cosmic-panel-config/config.ron
@@ -35,7 +35,7 @@
             spacing: 2,
             exclusive_zone: true,
             autohide: None,
-            border_radius: 0,
+            border_radius: Some(0),
             margin: 0,
             opacity: 1.0
         ),
@@ -65,7 +65,7 @@
                 transition_time: 200,
                 handle_size: 2,
             )),
-            border_radius: 160,
+            border_radius: None,
             margin: 0,
             opacity: 1.0
         ),

--- a/cosmic-panel-config/src/container_config.rs
+++ b/cosmic-panel-config/src/container_config.rs
@@ -167,7 +167,7 @@ impl Default for CosmicPanelContainerConfig {
                     expand_to_edges: true,
                     padding: 0,
                     spacing: 0,
-                    border_radius: 0,
+                    border_radius: Some(0),
                     exclusive_zone: true,
                     autohide: None,
                     margin: 0,
@@ -198,7 +198,7 @@ impl Default for CosmicPanelContainerConfig {
                     expand_to_edges: false,
                     padding: 4,
                     spacing: 0,
-                    border_radius: 12,
+                    border_radius: None,
                     exclusive_zone: false,
                     autohide: Some(crate::AutoHide {
                         wait_time: 500,

--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -396,7 +396,7 @@ pub struct CosmicPanelConfig {
     pub padding: u32,
     /// space between panel plugins
     pub spacing: u32,
-    pub border_radius: u32,
+    pub border_radius: Option<u32>,
     // TODO autohide & exclusive zone should not be able to both be enabled at once
     /// exclusive zone
     pub exclusive_zone: bool,
@@ -462,7 +462,7 @@ impl Default for CosmicPanelConfig {
             spacing: 0,
             exclusive_zone: true,
             autohide: Some(AutoHide::default()),
-            border_radius: 8,
+            border_radius: None,
             margin: 4,
             opacity: 0.8,
             autohover_delay_ms: Some(500),
@@ -694,7 +694,7 @@ impl CosmicPanelConfig {
         }
         self.expand_to_edges = true;
         self.margin = 0;
-        self.border_radius = 0;
+        self.border_radius = Some(0);
         self.anchor_gap = false;
     }
 }


### PR DESCRIPTION
This PR fixes issue pop-os/cosmic-epoch#2802 where the dock's corner radius did not match the "Slightly Round" system theme (or other user-selected corner radii).

**Changes:**
- Modified `CosmicPanelConfig` to change `border_radius` from `u32` to `Option<u32>`.
- Updated `cosmic-panel-bin` to use the theme's `corner_radius` when `border_radius` is `None`.
- Updated the default configuration:
    - `Panel` (Top Bar) explicitly sets `border_radius: Some(0)` (square/full-width).
    - `Dock` sets `border_radius: None` (adapts to system theme).

**Reasoning:**
The previous implementation used a hardcoded default of `8` (in `panel_config.rs`) or `12` (in `container_config.rs` for the Dock), which often clashed with the user's chosen theme settings. By allowing `None`, we enable the dock to dynamically match the rest of the desktop environment.

Fixes pop-os/cosmic-epoch#2802
