### PR TITLE
add option to keep panel style when windows are maximized

### DIFF
--- a/cosmic-panel-config/src/container_config.rs
+++ b/cosmic-panel-config/src/container_config.rs
@@ -174,6 +174,7 @@ impl Default for CosmicPanelContainerConfig {
                     opacity: 1.0,
                     autohover_delay_ms: Some(500),
                     padding_overlap: 0.5,
+                    keep_style_on_maximize: false,
                 },
                 CosmicPanelConfig {
                     name: "Dock".to_string(),
@@ -210,6 +211,7 @@ impl Default for CosmicPanelContainerConfig {
                     opacity: 1.0,
                     autohover_delay_ms: Some(500),
                     padding_overlap: 0.5,
+                    keep_style_on_maximize: false,
                 },
             ],
         }

--- a/cosmic-panel-config/src/panel_config.rs
+++ b/cosmic-panel-config/src/panel_config.rs
@@ -412,6 +412,9 @@ pub struct CosmicPanelConfig {
     pub autohover_delay_ms: Option<u32>,
     /// padding overlap ratio
     pub padding_overlap: f32,
+    /// keep panel styling when windows are maximized
+    #[serde(default)]
+    pub keep_style_on_maximize: bool,
 }
 
 impl PartialEq for CosmicPanelConfig {
@@ -438,6 +441,7 @@ impl PartialEq for CosmicPanelConfig {
             && self.size_center == other.size_center
             && self.size_wings == other.size_wings
             && (self.opacity - other.opacity).abs() < 0.01
+            && self.keep_style_on_maximize == other.keep_style_on_maximize
     }
 }
 
@@ -467,6 +471,7 @@ impl Default for CosmicPanelConfig {
             opacity: 0.8,
             autohover_delay_ms: Some(500),
             padding_overlap: 0.5,
+            keep_style_on_maximize: false,
         }
     }
 }
@@ -688,10 +693,10 @@ impl CosmicPanelConfig {
     }
 
     pub fn maximize(&mut self) {
-        self.opacity = 1.0;
-        if self.autohide().is_some() {
+        if self.keep_style_on_maximize || self.autohide().is_some() {
             return;
         }
+        self.opacity = 1.0;
         self.expand_to_edges = true;
         self.margin = 0;
         self.border_radius = 0;


### PR DESCRIPTION
adds a keep_style_on_maximize config option for panels/docks. when enabled, the panel won't change its appearance when a window is maximized - it keeps the user's configured expand_to_edges, margin, border_radius, anchor_gap, and opacity settings instead of forcing them to the maximized defaults.

this addresses the issue where users who prefer the floating/island style (like macos) see their panel snap to full-width with no gaps when maximizing windows.

relates to #519