### PR TITLE
Fixes for touch input

### DIFF
--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -340,6 +340,18 @@ impl WrapperSpace for PanelSpace {
         Ok(())
     }
 
+    fn grab_popup(
+        &mut self,
+        popup: PopupSurface,
+        seat: wl_seat::WlSeat,
+        serial: u32,
+    ) -> anyhow::Result<()> {
+        if let Some(p) = self.popups.iter().find(|wp| wp.s_surface == popup) {
+            p.popup.c_popup.xdg_popup().grab(&seat, serial);
+        }
+        Ok(())
+    }
+
     fn reposition_popup(
         &mut self,
         popup: PopupSurface,

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -191,8 +191,6 @@ impl WrapperSpace for PanelSpace {
         s_surface: PopupSurface,
         positioner: sctk::shell::xdg::XdgPositioner,
         positioner_state: PositionerState,
-        latest_seat: &wl_seat::WlSeat,
-        latest_serial: u32,
     ) -> anyhow::Result<()> {
         self.apply_positioner_state(&positioner, positioner_state, &s_surface);
         let c_wl_surface = compositor_state.create_surface(qh);
@@ -285,14 +283,7 @@ impl WrapperSpace for PanelSpace {
                 area = area.saturating_add(r.1.size.w.saturating_mul(r.1.size.h));
                 input_region.add(0, 0, r.1.size.w, r.1.size.h);
             }
-            // must take a grab on all popups to avoid being closed automatically by focus
-            // follows cursor...
-            if area > 1 {
-                c_popup.xdg_popup().grab(latest_seat, latest_serial);
-            }
             c_wl_surface.set_input_region(Some(input_region.wl_region()));
-        } else {
-            c_popup.xdg_popup().grab(latest_seat, latest_serial);
         }
         let fractional_scale =
             fractional_scale_manager.map(|f| f.fractional_scaling(&c_wl_surface, qh));

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -176,8 +176,6 @@ impl WrapperSpace for PanelSpace {
         s_surface: PopupSurface,
         positioner: sctk::shell::xdg::XdgPositioner,
         positioner_state: PositionerState,
-        latest_seat: &wl_seat::WlSeat,
-        latest_serial: u32,
     ) -> anyhow::Result<()> {
         self.apply_positioner_state(&positioner, positioner_state, &s_surface);
         let c_wl_surface = compositor_state.create_surface(qh);
@@ -270,14 +268,7 @@ impl WrapperSpace for PanelSpace {
                 area = area.saturating_add(r.1.size.w.saturating_mul(r.1.size.h));
                 input_region.add(0, 0, r.1.size.w, r.1.size.h);
             }
-            // must take a grab on all popups to avoid being closed automatically by focus
-            // follows cursor...
-            if area > 1 {
-                c_popup.xdg_popup().grab(latest_seat, latest_serial);
-            }
             c_wl_surface.set_input_region(Some(input_region.wl_region()));
-        } else {
-            c_popup.xdg_popup().grab(latest_seat, latest_serial);
         }
         let fractional_scale =
             fractional_scale_manager.map(|f| f.fractional_scaling(&c_wl_surface, qh));

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -1388,16 +1388,29 @@ impl WrapperSpace for PanelSpace {
     }
 
     fn keyboard_leave(&mut self, seat_name: &str, f: Option<c_wl_surface::WlSurface>) {
-        // if not a leaf, return early
-        if let Some(surface) = f.as_ref()
-            && self.popups.iter().any(|p| p.popup.parent == *surface)
-        {
-            return;
-        }
-        if self.layer.as_ref().zip(f).is_some_and(|l| l.0.wl_surface() == &l.1)
-            && (self.popups.iter().any(|p| p.popup.grab) || self.overflow_popup.is_some())
-        {
-            return;
+        if let Some(surface) = f.as_ref() {
+            // if not a leaf, return early
+            if self.popups.iter().any(|p| p.popup.parent == *surface) {
+                return;
+            }
+
+            if self.layer.as_ref().is_some_and(|l| l.wl_surface() == surface)
+                && (self.popups.iter().any(|p| p.popup.grab) || self.overflow_popup.is_some())
+            {
+                return;
+            }
+
+            // Ignore event for wl_surface that isn't our layer or popup (i.e. a different
+            // panel)
+            if !self.layer.as_ref().is_some_and(|l| l.wl_surface() == surface)
+                && !self
+                    .overflow_popup
+                    .as_ref()
+                    .is_some_and(|(p, _)| p.c_popup.wl_surface() == surface)
+                && !self.popups.iter().any(|p| p.popup.c_popup.wl_surface() == surface)
+            {
+                return;
+            }
         }
 
         self.s_focused_surface.retain(|(_, name)| name != seat_name);

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -327,6 +327,18 @@ impl WrapperSpace for PanelSpace {
         Ok(())
     }
 
+    fn grab_popup(
+        &mut self,
+        popup: PopupSurface,
+        seat: wl_seat::WlSeat,
+        serial: u32,
+    ) -> anyhow::Result<()> {
+        if let Some(p) = self.popups.iter().find(|wp| wp.s_surface == popup) {
+            p.popup.c_popup.xdg_popup().grab(&seat, serial);
+        }
+        Ok(())
+    }
+
     fn reposition_popup(
         &mut self,
         popup: PopupSurface,

--- a/cosmic-panel-bin/src/space_container/mod.rs
+++ b/cosmic-panel-bin/src/space_container/mod.rs
@@ -2,9 +2,27 @@
 //! separate panel space container implements the WrapperSpace abstraction,
 //! calling handle events and other methods of its PanelSpaces as necessary
 
+use crate::space::PanelSpace;
+
 mod space_container;
 pub(crate) mod toplevel;
 pub(crate) mod workspace;
 mod wrapper_space;
 
 pub use space_container::*;
+
+fn space_for_client_mut(
+    space_list: &mut [PanelSpace],
+    client: Option<wayland_backend::server::ClientId>,
+) -> Option<&mut PanelSpace> {
+    space_list.iter_mut().find(|space| {
+        space
+            .clients_center
+            .lock()
+            .unwrap()
+            .iter()
+            .chain(space.clients_left.lock().unwrap().iter())
+            .chain(space.clients_right.lock().unwrap().iter())
+            .any(|c| c.client.as_ref().zip(client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
+    })
+}

--- a/cosmic-panel-bin/src/space_container/mod.rs
+++ b/cosmic-panel-bin/src/space_container/mod.rs
@@ -2,9 +2,32 @@
 //! separate panel space container implements the WrapperSpace abstraction,
 //! calling handle events and other methods of its PanelSpaces as necessary
 
+use crate::space::PanelSpace;
+
 mod space_container;
 pub(crate) mod toplevel;
 pub(crate) mod workspace;
 mod wrapper_space;
 
 pub use space_container::*;
+
+fn space_has_client(
+    space: &PanelSpace,
+    client: Option<&wayland_backend::server::ClientId>,
+) -> bool {
+    space
+        .clients_center
+        .lock()
+        .unwrap()
+        .iter()
+        .chain(space.clients_left.lock().unwrap().iter())
+        .chain(space.clients_right.lock().unwrap().iter())
+        .any(|c| c.client.as_ref().zip(client.as_ref()).is_some_and(|c| c.0.id() == **c.1))
+}
+
+fn space_for_client_mut<'a>(
+    space_list: &'a mut [PanelSpace],
+    client: Option<&wayland_backend::server::ClientId>,
+) -> Option<&'a mut PanelSpace> {
+    space_list.iter_mut().find(|space| space_has_client(space, client))
+}

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -47,6 +47,8 @@ use tokio::sync::mpsc;
 use tracing::{error, info};
 use wayland_server::Resource;
 
+use super::space_for_client_mut;
+
 pub struct SpaceContainer {
     pub(crate) connection: Option<Connection>,
     pub(crate) config: CosmicPanelContainerConfig,
@@ -566,16 +568,7 @@ impl SpaceContainer {
         // add window to the space with a client that matches the window
         let s_client = wlsurface.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().map(|c| c.id()) == s_client)
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, s_client) {
             space.dirty_subsurface(
                 self.renderer.as_mut(),
                 compositor_state,

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -43,6 +43,8 @@ use tracing::{error, info};
 use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1;
 use wayland_server::Resource;
 
+use super::space_for_client_mut;
+
 pub struct SpaceContainer {
     pub(crate) connection: Option<Connection>,
     pub(crate) config: CosmicPanelContainerConfig,
@@ -602,16 +604,7 @@ impl SpaceContainer {
         // add window to the space with a client that matches the window
         let s_client = wlsurface.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().map(|c| c.id()) == s_client)
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, s_client.as_ref()) {
             space.dirty_subsurface(
                 self.renderer.as_mut(),
                 compositor_state,

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -347,6 +347,21 @@ impl WrapperSpace for SpaceContainer {
         }
     }
 
+    fn grab_popup(
+        &mut self,
+        s_surface: smithay::wayland::shell::xdg::PopupSurface,
+        seat: WlSeat,
+        serial: u32,
+    ) -> anyhow::Result<()> {
+        let p_client = s_surface.wl_surface().client().map(|c| c.id());
+
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client) {
+            space.grab_popup(s_surface, seat, serial)
+        } else {
+            anyhow::bail!("Failed to find popup with matching client id")
+        }
+    }
+
     fn reposition_popup(
         &mut self,
         popup: smithay::wayland::shell::xdg::PopupSurface,

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -40,7 +40,7 @@ use smithay::{
 
 use crate::space::PanelSpace;
 
-use super::SpaceContainer;
+use super::{SpaceContainer, space_for_client_mut};
 
 impl WrapperSpace for SpaceContainer {
     type Config = CosmicPanelContainerConfig;
@@ -310,16 +310,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let w_client = s_top_level.toplevel().and_then(|t| t.wl_surface().client().map(|c| c.id()));
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(w_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, w_client) {
             space.add_window(s_top_level);
         }
     }
@@ -341,16 +332,7 @@ impl WrapperSpace for SpaceContainer {
         // add popup to the space with a client that matches the window
         let p_client = s_surface.wl_surface().client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client) {
             space.add_popup(
                 compositor_state,
                 fractional_scale_manager,
@@ -378,16 +360,7 @@ impl WrapperSpace for SpaceContainer {
         // add popup to the space with a client that matches the window
         let p_client = popup.wl_surface().client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client) {
             space.reposition_popup(popup, positioner_state, token)?
         }
         anyhow::bail!("Failed to find popup with matching client id")
@@ -446,16 +419,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let w_client = w.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(w_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, w_client) {
             space.dirty_window(dh, w);
         }
     }
@@ -468,16 +432,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let p_client = w.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client) {
             space.dirty_popup(dh, w);
         }
     }

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -326,8 +326,6 @@ impl WrapperSpace for SpaceContainer {
         s_surface: smithay::wayland::shell::xdg::PopupSurface,
         positioner: sctk::shell::xdg::XdgPositioner,
         positioner_state: smithay::wayland::shell::xdg::PositionerState,
-        c_seat: &WlSeat,
-        last_serial: u32,
     ) -> anyhow::Result<()> {
         // add popup to the space with a client that matches the window
         let p_client = s_surface.wl_surface().client().map(|c| c.id());
@@ -343,8 +341,6 @@ impl WrapperSpace for SpaceContainer {
                 s_surface,
                 positioner,
                 positioner_state,
-                c_seat,
-                last_serial,
             )
         } else {
             anyhow::bail!("failed to find a matching panel space for this popup.")

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -29,7 +29,7 @@ use smithay::reexports::wayland_server::{self, Resource};
 
 use crate::space::PanelSpace;
 
-use super::SpaceContainer;
+use super::{SpaceContainer, space_for_client_mut, space_has_client};
 
 impl WrapperSpace for SpaceContainer {
     type Config = CosmicPanelContainerConfig;
@@ -309,16 +309,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let w_client = s_top_level.toplevel().and_then(|t| t.wl_surface().client().map(|c| c.id()));
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(w_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, w_client.as_ref()) {
             space.add_window(s_top_level);
         }
     }
@@ -340,16 +331,9 @@ impl WrapperSpace for SpaceContainer {
         // add popup to the space with a client that matches the window
         let p_client = s_surface.wl_surface().client().map(|c| c.id());
 
-        let Some(idx) = self.space_list.iter().position(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) else {
+        let Some(idx) =
+            self.space_list.iter().position(|space| space_has_client(space, p_client.as_ref()))
+        else {
             anyhow::bail!("failed to find a matching panel space for this popup.")
         };
 
@@ -383,16 +367,7 @@ impl WrapperSpace for SpaceContainer {
         // add popup to the space with a client that matches the window
         let p_client = popup.wl_surface().client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client.as_ref()) {
             space.reposition_popup(popup, positioner_state, token)?
         }
         anyhow::bail!("Failed to find popup with matching client id")
@@ -451,16 +426,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let w_client = w.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(w_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, w_client.as_ref()) {
             space.dirty_window(dh, w);
         }
     }
@@ -473,16 +439,7 @@ impl WrapperSpace for SpaceContainer {
         // add window to the space with a client that matches the window
         let p_client = w.client().map(|c| c.id());
 
-        if let Some(space) = self.space_list.iter_mut().find(|space| {
-            space
-                .clients_center
-                .lock()
-                .unwrap()
-                .iter()
-                .chain(space.clients_left.lock().unwrap().iter())
-                .chain(space.clients_right.lock().unwrap().iter())
-                .any(|c| c.client.as_ref().zip(p_client.as_ref()).is_some_and(|c| c.0.id() == *c.1))
-        }) {
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client.as_ref()) {
             space.dirty_popup(dh, w);
         }
     }

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -325,8 +325,6 @@ impl WrapperSpace for SpaceContainer {
         s_surface: smithay::wayland::shell::xdg::PopupSurface,
         positioner: sctk::shell::xdg::XdgPositioner,
         positioner_state: smithay::wayland::shell::xdg::PositionerState,
-        c_seat: &WlSeat,
-        last_serial: u32,
     ) -> anyhow::Result<()> {
         // add popup to the space with a client that matches the window
         let p_client = s_surface.wl_surface().client().map(|c| c.id());
@@ -353,8 +351,6 @@ impl WrapperSpace for SpaceContainer {
             s_surface,
             positioner,
             positioner_state,
-            c_seat,
-            last_serial,
         )
     }
 

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -354,6 +354,21 @@ impl WrapperSpace for SpaceContainer {
         )
     }
 
+    fn grab_popup(
+        &mut self,
+        s_surface: smithay::wayland::shell::xdg::PopupSurface,
+        seat: WlSeat,
+        serial: u32,
+    ) -> anyhow::Result<()> {
+        let p_client = s_surface.wl_surface().client().map(|c| c.id());
+
+        if let Some(space) = space_for_client_mut(&mut self.space_list, p_client.as_ref()) {
+            space.grab_popup(s_surface, seat, serial)
+        } else {
+            anyhow::bail!("Failed to find popup with matching client id")
+        }
+    }
+
     fn reposition_popup(
         &mut self,
         popup: smithay::wayland::shell::xdg::PopupSurface,

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/xdg_shell.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/xdg_shell.rs
@@ -2,6 +2,7 @@ use itertools::Itertools;
 use sctk::shell::xdg::XdgPositioner;
 use smithay::delegate_xdg_shell;
 use smithay::desktop::{PopupKind, Window};
+use smithay::input::Seat;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel;
 use smithay::reexports::wayland_server::protocol::wl_seat;
 use smithay::utils::{SERIAL_COUNTER, Serial};
@@ -76,7 +77,17 @@ impl XdgShellHandler for GlobalState {
     ) {
     }
 
-    fn grab(&mut self, _surface: PopupSurface, _seat: wl_seat::WlSeat, _serial: Serial) {
+    // TODO: Validate serial
+    fn grab(&mut self, surface: PopupSurface, seat: wl_seat::WlSeat, _serial: Serial) {
+        let seat = Seat::from_resource(&seat).unwrap();
+        let Some(seat_pair) = self.server_state.seats.iter().find(|s| s.server.seat == seat) else {
+            return;
+        };
+        let _ = self.space.grab_popup(
+            surface,
+            seat_pair.client._seat.clone(),
+            seat_pair.client.get_serial_of_last_seat_event(),
+        );
         if let Some(cosmic_workspaces) = &self.space.shared.cosmic_workspaces {
             cosmic_workspaces.hide();
         }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/xdg_shell.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/xdg_shell.rs
@@ -31,14 +31,7 @@ impl XdgShellHandler for GlobalState {
             Ok(p) => p,
             Err(_) => return,
         };
-        if let Some(f_seat) = self.server_state.seats.iter().find(|s| {
-            self.client_state
-                .hovered_surface
-                .borrow()
-                .iter()
-                .chain(self.client_state.focused_surface.borrow().iter())
-                .any(|f| f.1 == s.name && matches!(f.2, FocusStatus::Focused))
-        }) && self
+        if self
             .space
             .add_popup(
                 &self.client_state.compositor_state,
@@ -50,8 +43,6 @@ impl XdgShellHandler for GlobalState {
                 surface.clone(),
                 positioner,
                 positioner_state,
-                &f_seat.client._seat,
-                f_seat.client.get_serial_of_last_seat_event(),
             )
             .is_ok()
         {

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -188,6 +188,9 @@ pub trait WrapperSpace {
         positioner_state: PositionerState,
     ) -> anyhow::Result<()>;
 
+    /// Add a grab for the popup
+    fn grab_popup(&mut self, popup: PopupSurface, seat: WlSeat, serial: u32) -> anyhow::Result<()>;
+
     /// handle a button press or release on a client surface
     /// optionally returns an interacted server wl surface
     fn handle_button(&mut self, seat_name: &str, press: bool) -> Option<SpaceTarget>;

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -186,8 +186,6 @@ pub trait WrapperSpace {
         s_surface: PopupSurface,
         positioner: XdgPositioner,
         positioner_state: PositionerState,
-        latest_seat: &WlSeat,
-        latest_serial: u32,
     ) -> anyhow::Result<()>;
 
     /// handle a button press or release on a client surface

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -166,8 +166,6 @@ pub trait WrapperSpace {
         s_surface: PopupSurface,
         positioner: XdgPositioner,
         positioner_state: PositionerState,
-        latest_seat: &WlSeat,
-        latest_serial: u32,
     ) -> anyhow::Result<()>;
 
     /// handle a button press or release on a client surface

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/space.rs
@@ -168,6 +168,9 @@ pub trait WrapperSpace {
         positioner_state: PositionerState,
     ) -> anyhow::Result<()>;
 
+    /// Add a grab for the popup
+    fn grab_popup(&mut self, popup: PopupSurface, seat: WlSeat, serial: u32) -> anyhow::Result<()>;
+
     /// handle a button press or release on a client surface
     /// optionally returns an interacted server wl surface
     fn handle_button(&mut self, seat_name: &str, press: bool) -> Option<SpaceTarget>;


### PR DESCRIPTION
The two fixes here seem to solve the same problem as https://github.com/pop-os/cosmic-panel/pull/470 in a cleaner way.

* Ignore `keyboard_leave` events for a different panel, instead of closing popups
* Create popup and grab even if there is no hovered surface (as expected with touch)

The later change though seems to basically be a revert of https://github.com/pop-os/cosmic-panel/pull/424, looking at the history of this code. But I don't really understand why that fix was needed. The applet clients create grabs, so cosmic-panel ends up creating a grab either way? Nor should "focus follows cursor" require a grab (or that would presumably be a compositor bug), and I'm not seeing issues with that...