### PR TITLE
cosmic-panel crash hardening

### DIFF
--- a/cosmic-panel-bin/src/config_watching.rs
+++ b/cosmic-panel-bin/src/config_watching.rs
@@ -53,13 +53,17 @@ pub fn watch_cosmic_theme(
     let theme_watcher_mode = config_mode_helper
         .watch(move |helper, _keys| match ThemeMode::get_entry(helper) {
             Ok(entry) => {
-                entries_tx_clone.send(ThemeUpdate::Mode(entry.is_dark)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Mode(entry.is_dark)) {
+                    tracing::warn!("Failed to send theme mode update: {e}");
+                }
             },
             Err((err, entry)) => {
                 for e in err {
                     error!("Failed to get theme entry value: {:?}", e);
                 }
-                entries_tx_clone.send(ThemeUpdate::Mode(entry.is_dark)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Mode(entry.is_dark)) {
+                    tracing::warn!("Failed to send theme mode update: {e}");
+                }
             },
         })
         .map_err(|e| anyhow!(format!("{:?}", e)))?;
@@ -68,13 +72,17 @@ pub fn watch_cosmic_theme(
     let theme_watcher_light = config_light_helper
         .watch(move |helper, _keys| match Theme::get_entry(helper) {
             Ok(entry) => {
-                entries_tx_clone.send(ThemeUpdate::Light(entry)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Light(entry)) {
+                    tracing::warn!("Failed to send light theme update: {e}");
+                }
             },
             Err((err, entry)) => {
                 for e in err {
                     error!("Failed to get theme entry value: {:?}", e);
                 }
-                entries_tx_clone.send(ThemeUpdate::Light(entry)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Light(entry)) {
+                    tracing::warn!("Failed to send light theme update: {e}");
+                }
             },
         })
         .map_err(|e| anyhow!(format!("{:?}", e)))?;
@@ -83,13 +91,17 @@ pub fn watch_cosmic_theme(
     let theme_watcher_dark = config_dark_helper
         .watch(move |helper, _keys| match Theme::get_entry(helper) {
             Ok(entry) => {
-                entries_tx_clone.send(ThemeUpdate::Dark(entry)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Dark(entry)) {
+                    tracing::warn!("Failed to send dark theme update: {e}");
+                }
             },
             Err((err, entry)) => {
                 for e in err {
                     error!("Failed to get theme entry value: {:?}", e);
                 }
-                entries_tx_clone.send(ThemeUpdate::Dark(entry)).unwrap();
+                if let Err(e) = entries_tx_clone.send(ThemeUpdate::Dark(entry)) {
+                    tracing::warn!("Failed to send dark theme update: {e}");
+                }
             },
         })
         .map_err(|e| anyhow!(format!("{:?}", e)))?;
@@ -135,24 +147,33 @@ pub fn watch_config(
 
                     let entries_tx_clone = entries_tx_clone.clone();
                     let name_clone = entry.name.clone();
-                    let helper = CosmicPanelConfig::cosmic_config(&name_clone)
-                        .expect("Failed to load cosmic config");
-                    let watcher = helper
-                        .watch(move |helper, _keys| {
-                            let new = match CosmicPanelConfig::get_entry(helper) {
-                                Ok(entry) => entry,
-                                Err((err, entry)) => {
-                                    for error in err {
-                                        error!("Failed to get entry value: {:?}", error);
-                                    }
-                                    entry
-                                },
-                            };
-                            entries_tx_clone
-                                .send(ConfigUpdate::EntryChanged(new))
-                                .expect("Failed to send Config Update");
-                        })
-                        .expect("Failed to watch cosmic config");
+                    let helper = match CosmicPanelConfig::cosmic_config(&name_clone) {
+                        Ok(h) => h,
+                        Err(err) => {
+                            error!("Failed to load cosmic config for {name_clone}: {err:?}");
+                            continue;
+                        },
+                    };
+                    let watcher = match helper.watch(move |helper, _keys| {
+                        let new = match CosmicPanelConfig::get_entry(helper) {
+                            Ok(entry) => entry,
+                            Err((err, entry)) => {
+                                for error in err {
+                                    error!("Failed to get entry value: {:?}", error);
+                                }
+                                entry
+                            },
+                        };
+                        if let Err(e) = entries_tx_clone.send(ConfigUpdate::EntryChanged(new)) {
+                            tracing::warn!("Failed to send config update: {e}");
+                        }
+                    }) {
+                        Ok(w) => w,
+                        Err(err) => {
+                            error!("Failed to watch cosmic config for {name_clone}: {err:?}");
+                            continue;
+                        },
+                    };
                     state.space.watchers.insert(entry.name.clone(), watcher);
 
                     state.space.update_space(
@@ -195,49 +216,58 @@ pub fn watch_config(
         };
     })?;
 
-    let cosmic_config_entries =
-        CosmicPanelContainerConfig::cosmic_config().expect("Failed to load cosmic config");
+    let cosmic_config_entries = CosmicPanelContainerConfig::cosmic_config()
+        .map_err(|e| anyhow!(format!("Failed to load cosmic panel container config: {e:?}")))?;
     info!("Watching panel config entries for changes {:?}", cosmic_config_entries);
 
     let entries_tx_clone = entries_tx.clone();
     let entries_watcher = cosmic_config_entries
         .watch(move |helper, keys| match helper.get::<Vec<String>>(&keys[0]) {
             Ok(entries) => {
-                entries_tx_clone
-                    .send(ConfigUpdate::Entries(entries))
-                    .expect("Failed to send entries");
+                if let Err(e) = entries_tx_clone.send(ConfigUpdate::Entries(entries)) {
+                    tracing::warn!("Failed to send config entries update: {e}");
+                }
             },
             Err(err) => {
                 error!("Failed to get entries: {:?}", err);
             },
         })
-        .expect("Failed to watch cosmic config");
+        .map_err(|e| anyhow!(format!("Failed to watch cosmic panel container config: {e:?}")))?;
 
     let mut watchers = HashMap::from([("entries".to_string(), entries_watcher)]);
 
     for entry in &config.config_list {
         let entries_tx_clone = entries_tx.clone();
         let name_clone = entry.name.clone();
-        let helper =
-            CosmicPanelConfig::cosmic_config(&name_clone).expect("Failed to load cosmic config");
+        let helper = match CosmicPanelConfig::cosmic_config(&name_clone) {
+            Ok(h) => h,
+            Err(err) => {
+                error!("Failed to load cosmic config for {name_clone}: {err:?}");
+                continue;
+            },
+        };
         info!("Watching panel config entry: {:?}", helper);
-        let watcher = helper
-            .watch(move |helper, keys| {
-                info!("Entry changed: {:?}", keys);
-                let new = match CosmicPanelConfig::get_entry(helper) {
-                    Ok(entry) => entry,
-                    Err((err, entry)) => {
-                        for error in err {
-                            error!("Failed to get entry value: {:?}", error);
-                        }
-                        entry
-                    },
-                };
-                entries_tx_clone
-                    .send(ConfigUpdate::EntryChanged(new))
-                    .expect("Failed to send Config Update");
-            })
-            .expect("Failed to watch cosmic config");
+        let watcher = match helper.watch(move |helper, keys| {
+            info!("Entry changed: {:?}", keys);
+            let new = match CosmicPanelConfig::get_entry(helper) {
+                Ok(entry) => entry,
+                Err((err, entry)) => {
+                    for error in err {
+                        error!("Failed to get entry value: {:?}", error);
+                    }
+                    entry
+                },
+            };
+            if let Err(e) = entries_tx_clone.send(ConfigUpdate::EntryChanged(new)) {
+                tracing::warn!("Failed to send config update: {e}");
+            }
+        }) {
+            Ok(w) => w,
+            Err(err) => {
+                error!("Failed to watch cosmic config for {name_clone}: {err:?}");
+                continue;
+            },
+        };
         watchers.insert(entry.name.clone(), watcher);
     }
 

--- a/cosmic-panel-bin/src/main.rs
+++ b/cosmic-panel-bin/src/main.rs
@@ -316,6 +316,19 @@ fn main() -> Result<()> {
     client_state.init_workspace_state();
     client_state.init_toplevel_info_state();
     client_state.init_toplevel_manager_state();
-    run(space, client_state, server_state, event_loop, server_display)?;
-    Ok(())
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        run(space, client_state, server_state, event_loop, server_display)
+    }));
+    match result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(e)) => {
+            error!("Panel exited with error: {e:?}");
+            std::process::exit(1);
+        },
+        Err(panic_info) => {
+            error!("Panel panicked: {panic_info:?}");
+            std::process::exit(1);
+        },
+    }
 }

--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -553,7 +553,7 @@ impl PanelSpace {
         // update input region of panel when list changes
         let (input_region, layer) = match (self.input_region.as_ref(), self.layer.as_ref()) {
             (Some(r), Some(layer)) => (r, layer),
-            _ => panic!("input region or layer missing"),
+            _ => anyhow::bail!("input region or layer missing, skipping layout"),
         };
 
         // must use logical coordinates for layout here
@@ -601,7 +601,7 @@ impl PanelSpace {
         // placed before the overflow button
         if windows_left.is_empty() && !windows_center.is_empty() && is_overlapping_start {
             let (_, CosmicMappedInternal::Spacer(s), ..) = windows_center.remove(0) else {
-                panic!("No spacer found");
+                anyhow::bail!("Expected spacer at beginning of center list, skipping layout");
             };
             let size = s.bbox().size.to_f64();
             let crosswise_pos = if self.config.is_horizontal() {

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -1639,10 +1639,13 @@ impl PanelSpace {
         // can't animate anchor changes
         // return early
         if config.anchor() != self.config.anchor() {
-            panic!(
-                "Can't apply anchor changes when orientation changes. Requires re-creation of the \
-                 panel."
+            tracing::error!(
+                "Cannot apply anchor change from {:?} to {:?} without panel re-creation, \
+                 ignoring config update",
+                self.config.anchor(),
+                config.anchor()
             );
+            return;
         }
 
         let mut needs_commit = false;

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -5,7 +5,7 @@ use std::os::unix::prelude::AsRawFd;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use std::{fs, mem, panic};
+use std::{fs, mem};
 
 use crate::iced::elements::PopupMappedInternal;
 use crate::iced::elements::target::SpaceTarget;
@@ -385,9 +385,12 @@ impl WrapperSpace for PanelSpace {
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                .map(|name| {
-                    let (c, s) = get_client_sock(&mut display);
-                    PanelClient::new(name, None, c, Some(s))
+                .filter_map(|name| match get_client_sock(&mut display) {
+                    Ok((c, s)) => Some(PanelClient::new(name, None, c, Some(s))),
+                    Err(e) => {
+                        tracing::error!("Failed to create client socket for applet {name}: {e}");
+                        None
+                    },
                 })
                 .collect();
 
@@ -398,9 +401,12 @@ impl WrapperSpace for PanelSpace {
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                .map(|name| {
-                    let (c, s) = get_client_sock(&mut display);
-                    PanelClient::new(name, None, c, Some(s))
+                .filter_map(|name| match get_client_sock(&mut display) {
+                    Ok((c, s)) => Some(PanelClient::new(name, None, c, Some(s))),
+                    Err(e) => {
+                        tracing::error!("Failed to create client socket for applet {name}: {e}");
+                        None
+                    },
                 })
                 .collect();
 
@@ -411,9 +417,12 @@ impl WrapperSpace for PanelSpace {
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                .map(|name| {
-                    let (c, s) = get_client_sock(&mut display);
-                    PanelClient::new(name, None, c, Some(s))
+                .filter_map(|name| match get_client_sock(&mut display) {
+                    Ok((c, s)) => Some(PanelClient::new(name, None, c, Some(s))),
+                    Err(e) => {
+                        tracing::error!("Failed to create client socket for applet {name}: {e}");
+                        None
+                    },
                 })
                 .collect();
 
@@ -594,7 +603,11 @@ impl WrapperSpace for PanelSpace {
                 let id_clone_info = panel_client.name.clone();
                 let id_clone_err = panel_client.name.clone();
                 let Some(client) = panel_client.client.as_ref() else {
-                    panic!("Failed to get client");
+                    tracing::error!(
+                        "Failed to get client for applet: {}, skipping",
+                        panel_client.name
+                    );
+                    continue;
                 };
                 let client_id = client.id();
                 let client_id_info = client.id();
@@ -660,8 +673,7 @@ impl WrapperSpace for PanelSpace {
                         let my_list = my_list.clone();
                         let mut display_handle = display_handle.clone();
                         let applet_tx_clone = applet_tx_clone.clone();
-                        let (c, client_socket) = get_client_sock(&mut display_handle);
-                        let raw_client_socket = client_socket.as_raw_fd();
+                        let client_sock_result = get_client_sock(&mut display_handle);
                         let mut applet_env = Vec::with_capacity(1);
                         let mut fds: Vec<OwnedFd> = Vec::with_capacity(2);
                         let should_restart = is_restarting && err_code.is_some();
@@ -697,6 +709,18 @@ impl WrapperSpace for PanelSpace {
                                 _ = pman.stop_process(key).await;
                                 return;
                             }
+
+                            let (c, client_socket) = match client_sock_result {
+                                Ok(pair) => pair,
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Failed to create client socket for applet restart: {e}"
+                                    );
+                                    _ = pman.stop_process(key).await;
+                                    return;
+                                },
+                            };
+                            let raw_client_socket = client_socket.as_raw_fd();
 
                             if is_notification_applet {
                                 let (tx, rx) = oneshot::channel();

--- a/cosmic-panel-bin/src/space_container/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space_container/wrapper_space.rs
@@ -776,8 +776,16 @@ impl WrapperSpace for SpaceContainer {
     }
 
     fn close_layer(&mut self, layer: &LayerSurface) {
+        let before = self.space_list.len();
         self.space_list
             .retain(|s| s.layer.as_ref().map(|s| s.wl_surface()) != Some(layer.wl_surface()));
+        let removed = before - self.space_list.len();
+        if removed > 0 {
+            tracing::warn!(
+                "Layer surface closed, removed {removed} panel space(s) ({} remaining)",
+                self.space_list.len()
+            );
+        }
     }
 
     fn output_leave(
@@ -786,7 +794,13 @@ impl WrapperSpace for SpaceContainer {
         _s_output: Output,
     ) -> anyhow::Result<()> {
         self.outputs.retain(|o| o.0 != c_output);
+        let before = self.space_list.len();
         self.space_list.retain(|s| s.output.as_ref().map(|o| &o.0) != Some(&c_output));
+        let removed = before - self.space_list.len();
+        tracing::info!(
+            "Output leave: removed {removed} panel space(s) ({} remaining)",
+            self.space_list.len()
+        );
         Ok(())
     }
 

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -95,6 +95,8 @@ pub fn run(
     // TODO find better place for this
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
+    const MAX_CONSECUTIVE_ERRORS: u32 = 10;
+    let mut consecutive_errors: u32 = 0;
     let mut prev_dur = Duration::from_millis(16);
     loop {
         let iter_start = Instant::now();
@@ -108,7 +110,23 @@ pub fn run(
         }
         .max(prev_dur);
 
-        event_loop.dispatch(dur, &mut global_state)?;
+        match event_loop.dispatch(dur, &mut global_state) {
+            Ok(()) => {
+                consecutive_errors = 0;
+            },
+            Err(e) => {
+                consecutive_errors += 1;
+                tracing::warn!(
+                    "Event loop dispatch error ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {e}"
+                );
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    tracing::error!("Too many consecutive dispatch errors, exiting");
+                    return Err(e.into());
+                }
+                std::thread::sleep(Duration::from_millis(50));
+                continue;
+            },
+        }
 
         // rendering
         {
@@ -118,7 +136,7 @@ pub fn run(
                 &s_dh,
                 &global_state.client_state.queue_handle,
                 &mut global_state.server_state.popup_manager,
-                global_state.start_time.elapsed().as_millis().try_into()?,
+                global_state.start_time.elapsed().as_millis().try_into().unwrap_or(u32::MAX),
                 Some(dur),
             );
         }
@@ -127,14 +145,18 @@ pub fn run(
         if let Some(renderer) = global_state.space.renderer() {
             global_state.client_state.draw_layer_surfaces(
                 renderer,
-                global_state.start_time.elapsed().as_millis().try_into()?,
+                global_state.start_time.elapsed().as_millis().try_into().unwrap_or(u32::MAX),
             );
         }
 
         // dispatch server events
         {
-            server_display.dispatch_clients(&mut global_state)?;
-            server_display.flush_clients()?;
+            if let Err(e) = server_display.dispatch_clients(&mut global_state) {
+                tracing::warn!("Server client dispatch error: {e}");
+            }
+            if let Err(e) = server_display.flush_clients() {
+                tracing::warn!("Server client flush error: {e}");
+            }
         }
         global_state.iter_count += 1;
 

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/egl_surface.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/egl_surface.rs
@@ -59,7 +59,7 @@ unsafe impl EGLNativeSurface for ClientEglSurface {
     ) -> Result<*const c_void, EGLError> {
         let ptr = self.wl_egl_surface.ptr();
         if ptr.is_null() {
-            panic!("recieved a null pointer for the wl_egl_surface.");
+            return Err(EGLError::BadNativeWindow);
         }
         wrap_egl_call_ptr(|| unsafe {
             ffi::egl::CreatePlatformWindowSurfaceEXT(

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/util.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/util.rs
@@ -22,18 +22,16 @@ pub fn smootherstep(t: f32) -> f32 {
 }
 
 /// helper function for inserting a wrapped applet client
-pub fn get_client_sock(display: &mut wayland_server::DisplayHandle) -> (Client, UnixStream) {
-    let (display_sock, client_sock) = UnixStream::pair().unwrap();
+pub fn get_client_sock(
+    display: &mut wayland_server::DisplayHandle,
+) -> Result<(Client, UnixStream)> {
+    let (display_sock, client_sock) = UnixStream::pair()?;
 
-    (
-        display
-            .insert_client(
-                display_sock,
-                Arc::new(WrapperClientCompositorState { compositor_state: Default::default() }),
-            )
-            .unwrap(),
-        client_sock,
-    )
+    let client = display.insert_client(
+        display_sock,
+        Arc::new(WrapperClientCompositorState { compositor_state: Default::default() }),
+    )?;
+    Ok((client, client_sock))
 }
 
 pub(crate) fn write_and_attach_buffer(


### PR DESCRIPTION
Main event loop resilience (xdg_shell_wrapper/mod.rs):
  - event_loop.dispatch() now counts consecutive errors and only exits after 10 failures, with 50ms backoff between retries
  - server_display.dispatch_clients() and flush_clients() log warnings instead of crashing
  - try_into() for elapsed time uses unwrap_or(u32::MAX) instead of ?

get_client_sock hardened (xdg_shell_wrapper/util.rs + 4 call sites in space/wrapper_space.rs):
  - Returns Result instead of panicking on socket creation failure
  - Call sites in plugin list initialization use filter_map to skip failed applets
  - On-exit restart handler checks the Result inside the async block and stops the process on failure

5 panics converted to error handling:
  - wrapper_space.rs:597 -- skips applet with continue instead of crashing
  - panel_space.rs:1642 -- logs error and returns instead of panicking on anchor mismatch
  - layout.rs:556,604 -- bail! instead of panic! (caller already discards errors)
  - egl_surface.rs:62 -- returns Err(EGLError::BadNativeWindow) instead of panicking

Panic safety net (main.rs):
  - run() wrapped in catch_unwind for clean exit on any remaining panics

Config watcher hardening (config_watching.rs):
  - All .unwrap() on channel sends converted to if let Err(e) with warnings
  - All .expect() on config loads/watches converted to match with error logging and continue

Diagnostic logging (space_container/wrapper_space.rs):
  - close_layer logs when panel spaces are removed
  - output_leave logs count of removed spaces on monitor disconnect

Likely fixes https://github.com/pop-os/cosmic-panel/issues/467.