### PR TITLE
layout: don't halve border radius

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -839,7 +839,7 @@ impl PanelSpace {
                 ],
             };
 
-            let border_radius = self.border_radius().min(w as u32).min(h as u32) as f32 / 2.;
+            let border_radius = (self.border_radius() as f32).min(w as f32 / 2.).min(h as f32 / 2.);
             let radius = match (self.config.anchor, self.gap()) {
                 (PanelAnchor::Right, 0) => [border_radius, 0., 0., border_radius],
                 (PanelAnchor::Left, 0) => [0., border_radius, border_radius, 0.],

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.93"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

This removes the division of the config border radius by 2, since it causes the panel to be squarer than it should be.

Not sure if the `w` and `h` in the `.min()` should be halved instead, but I can't see visual issues at high radius values with the current change (edit: I can't see any issues even when removing both `.min()`, so maybe they're unneeded?).
Would it be safe to remove them, or should maybe the division be moved inside the mins?

Edit: I removed them, since iced handles that automatically.