### PR TITLE
fix: increase autohide smoothness

### DIFF
--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -95,7 +95,20 @@ pub fn run(
     // TODO find better place for this
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
-    let mut prev_dur = Duration::from_millis(16);
+    fn get_refresh_rate(global_state: &GlobalState) -> i32 {
+        global_state.space.space_list.iter()
+            .filter_map(|panel| {
+                panel.output.as_ref()?.2.modes.iter()
+                    .find(|mode| mode.current)
+                    .map(|mode| mode.refresh_rate)
+            })
+            .max()
+            .unwrap()
+    }
+
+    let mut prev_refresh_rate = get_refresh_rate(&global_state);
+    let mut prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
+
     loop {
         let iter_start = Instant::now();
 
@@ -104,7 +117,7 @@ pub fn run(
         let dur = if matches!(global_state.space.visibility(), Visibility::Hidden) {
             Duration::from_millis(300)
         } else {
-            Duration::from_millis(16)
+            Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64)
         }
         .max(prev_dur);
 
@@ -141,17 +154,18 @@ pub fn run(
         let new_visibility_hidden = matches!(global_state.space.visibility(), Visibility::Hidden);
 
         if visibility != new_visibility_hidden {
-            prev_dur = Duration::from_millis(16);
+            prev_refresh_rate = get_refresh_rate(&global_state);
+            prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
             continue;
         }
         if let Some(dur) = Instant::now()
             .checked_duration_since(iter_start)
             .and_then(|spent| dur.checked_sub(spent))
         {
-            std::thread::sleep(dur.min(Duration::from_millis(if new_visibility_hidden {
-                50
+            std::thread::sleep(dur.min(Duration::from_nanos(if new_visibility_hidden {
+                50_000_000
             } else {
-                16
+                1_000_000_000_000 / prev_refresh_rate as u64
             })));
         } else {
             prev_dur = prev_dur.checked_mul(2).unwrap_or(prev_dur).min(Duration::from_millis(100));


### PR DESCRIPTION
## Summary

This PR aims to make the autohiding animation smoother by replacing the hard-coded 16ms event dispatch wait time with a dynamic value calculated from the monitor's refresh rate.

This PR is similar to #521 but takes a different approach that should work on monitors with high refresh rates (>60hz) and also when changing monitor refresh rates while the program is running.

## Problem

The dock and panel's autohide animation is very stuttery on most refresh rates including at 60hz which the current production version of `cosmic-panel` seems to approximately target. This stutter breaks the illusion that cosmic-panel (and possibly cosmic itself) is performant.

The issue seems to stem from two causes:

1. The animation render update frequency is constant regardless of the monitors' refresh rates.
2. The default update rate of 16ms which is not equivalent to 60hz, causing animation error.

## Limitations & Concerns

Since there is a single event loop for all panels, I can only set the dispatch wait time to a single value for all panels and monitors and keep my changes simple and small for my first contribution to the `cosmic-epoch` project. I chose to select the highest active refresh rate which wastes CPU/GPU cycles during the dock animation on monitors with a lower refresh rate than the selected one. However, since these cycles are running only _during_ the animation, I believe the cost of my solution is plenty **negligible enough** for the time being while the rest of the desktop is being developed and further/better solutions are proposed.

This raises a concern from me about animation error on the monitors with active refresh rates lower than the maximum monitor's due to a mismatch between the selected refresh rate (ref: [GamersNexus - The Problem with GPU Benchmarks | Reality vs. Numbers, Animation Error Methodology White Paper](https://youtu.be/qDnXe6N8h_c?si=QHKWTlYF8q6QGSP1&t=308)). For example, if I have two monitors at 144hz and 60hz with the 144hz rate selected, the monitor running at 60hz would skip every other frame plus an occasional extra which can make the animation feel choppy. Additionally, I believe this is why the panel from the `master` branch feels stuttery.

## Demo

This demo starts with the `cosmic-panel` running from the `master` branch, then once again after switching to my `dynamic-dispatch-duration` branch and recompiling/installing the program with my edits.

I was unable to record the debug output demonstrating the refresh rate change as changing the monitor's refresh rate mid-recording ruins the entire recording.

I've recorded this video at exactly half my monitor's refresh rate (72.99fps) as OBS doesn't like frame rates >120fps. I then had to compress it via Handbrake to fit within GitHub's 100MB file upload limit. Hopefully it appears nice on GitHub.

https://github.com/user-attachments/assets/6d6f5f96-6983-4e95-8ad3-4a59978dad21

## Testing Methodology

My PC is running Fedora 44 with cosmic 1.14 from the Fedora repos, so my listed commands will be Fedora-specific. For the sake of testing, I've replaced the stock `cosmic-panel` with 1.15 pulled from GitHub.

Since running the program alone results in two sets of docks/panels appearing at once, I've chosen to replace the system-installed `cosmic-panel`. For those unfamiliar with how this can be done:

1. Pull this repo and checkout this PR (yes, I'm glossing over this).
2. Run `just && sudo just install && pkill cosmic-panel` in the terminal to replace the old version.

To revert to the repo's version, simply run `sudo dnf reinstall cosmic-panel` or whatever your distro's equivalent command is.

However, definitively determine whether the refresh rate change occurred required me to add some debug code that simply prints the currently selected refresh rate. However to see the output, I needed to run the program from the CLI. Since I was only measuring whether the selected monitor's refresh rate changes, the doubled panel/dock was not an issue.

To detect animation error, I set the monitors to very different refresh rates that aren't multiples of each other and increased the `transition_time` field in `$USER/.config/cosmic/com.system76.CosmicPanel.Dock/v1/autohide`.

## Tests

Due to my current lack of profiling/tracing experience, I've chosen to stick with visual testing. Here are the test cases I wanted to check along with their results:

1. With 2 refresh rates that are **exactly** the same (ex: `143.973`hz and `143.973`hz)
    - This is here as a sanity check. It's impossible for me to test as my 2 monitors do not have any available refresh rates that match exactly. Additional testing is welcome if you have the hardware. However I suspect this would work without issue.
2. With 2 refresh rates that are **approximately** the same (ex: `143.973`hz and `143.855`hz)
    - Appears to work as expected without issue on both monitors.
3. With 2 refresh rates that are nowhere near the same (ex: `143.973`hz and `60.000`hz)
    - After setting the dock's transition time to `2000`, I was able to visually detect minor animation error on the 60hz monitor. You really have to look for it though.
4. With 2 refresh rates where the **max** refresh rate changes during runtime
    - Selected refresh rate changes when the show/hide animation is triggered just as expected.
5. With 2 refresh rates where the **min** refresh rate changes during runtime
    - Selected refresh rate does **not** change when the show/hide animation is triggered just as expected.
6. With a single monitor connected
    - Appears to work as expected without issue.
7. With a single monitor connected with a refresh rate that changes during runtime
    - Appears to work as expected without issue.
8. Triggering a refresh rate reselection via cursor hover
    - Appears to work as expected without issue.
9. Triggering a refresh rate reselection via window maximization
    - Appears to work as expected without issue.

The only issue I was able to detect was the presence of animation error on a monitor with a lower refresh rate, but I was unable to notice it with the default transition time of 200.

## PR Checks

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

---

Thank you for reading!

-- Alexander Anthis (NotYourAlejandro)