### PR TITLE
fix: pace panel render loop via frame callbacks

### DIFF
--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -3,7 +3,7 @@
 
 //! Provides the core functionality for cosmic-panel
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::Result;
 use sctk::shm::multi::MultiPool;
@@ -95,41 +95,27 @@ pub fn run(
     // TODO find better place for this
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
-    fn get_refresh_rate(global_state: &GlobalState) -> i32 {
-        global_state
-            .space
-            .space_list
-            .iter()
-            .filter_map(|panel| {
-                panel
-                    .output
-                    .as_ref()?
-                    .2
-                    .modes
-                    .iter()
-                    .find(|mode| mode.current)
-                    .map(|mode| mode.refresh_rate)
-            })
-            .max()
-            .unwrap_or(60)
-    }
-
-    let mut prev_refresh_rate = get_refresh_rate(&global_state);
-    let mut prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
-
+    // Pacing is driven by frame callbacks (`wl_surface.frame`), not a fixed
+    // timer. The Wayland client connection is a calloop source, so
+    // `event_loop.dispatch` returns as soon as the compositor sends the next
+    // frame callback. Rendering is gated on `has_frame` (see `Space::render`),
+    // so the panel emits at most one frame per callback and animates at the
+    // display's presentation rate without needing to know the refresh rate.
+    // The timeouts below are only upper bounds for when nothing else wakes us.
     loop {
-        let iter_start = Instant::now();
-
-        let visibility = matches!(global_state.space.visibility(), Visibility::Hidden);
-        // dispatch desktop client events
-        let dur = if matches!(global_state.space.visibility(), Visibility::Hidden) {
+        // Ceiling on how long to block, not the frame interval: a frame callback
+        // wakes `dispatch` earlier while animating, so animation is paced at the
+        // display's refresh rate. The embedded applet server is polled once per
+        // iteration via `dispatch_clients` (its fd is not a calloop source), so
+        // the visible ceiling stays tight (~60 Hz) to keep applet updates
+        // responsive; hidden panels can idle longer.
+        let dispatch_timeout = if matches!(global_state.space.visibility(), Visibility::Hidden) {
             Duration::from_millis(300)
         } else {
-            Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64)
-        }
-        .max(prev_dur);
+            Duration::from_millis(16)
+        };
 
-        event_loop.dispatch(dur, &mut global_state)?;
+        event_loop.dispatch(dispatch_timeout, &mut global_state)?;
 
         // rendering
         {
@@ -140,7 +126,7 @@ pub fn run(
                 &global_state.client_state.queue_handle,
                 &mut global_state.server_state.popup_manager,
                 global_state.start_time.elapsed().as_millis().try_into()?,
-                Some(dur),
+                Some(dispatch_timeout),
             );
         }
         global_state.draw_dnd_icon();
@@ -158,25 +144,5 @@ pub fn run(
             server_display.flush_clients()?;
         }
         global_state.iter_count += 1;
-
-        let new_visibility_hidden = matches!(global_state.space.visibility(), Visibility::Hidden);
-
-        if visibility != new_visibility_hidden {
-            prev_refresh_rate = get_refresh_rate(&global_state);
-            prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
-            continue;
-        }
-        if let Some(dur) = Instant::now()
-            .checked_duration_since(iter_start)
-            .and_then(|spent| dur.checked_sub(spent))
-        {
-            std::thread::sleep(dur.min(Duration::from_nanos(if new_visibility_hidden {
-                50_000_000
-            } else {
-                1_000_000_000_000 / prev_refresh_rate as u64
-            })));
-        } else {
-            prev_dur = prev_dur.checked_mul(2).unwrap_or(prev_dur).min(Duration::from_millis(100));
-        }
     }
 }


### PR DESCRIPTION
> **Note on authorship:** This change was developed with Claude Code (AI assistance). I have reviewed it in full, understand how and why it works (see "How pacing now follows `wl_surface.frame`" below), consider it correct and sensible, and will respond to review comments. The AI co-authorship is disclosed in the commit's `Co-Authored-By` trailer.

## Problem

Panel/dock autohide animations look choppy, most visibly on low-refresh outputs. The animation is time-based — each frame's position is computed from elapsed time — so smooth motion needs frames presented at *even intervals, aligned to the output's vblank*.

The render loop instead paced itself with a fixed `thread::sleep` (a constant ~16 ms before #612; the largest monitor's refresh period in #612). Rendering is gated on a per-surface `has_frame` flag that the compositor's `wl_surface.frame` callback sets, but that flag was only a gate — the loop's *cadence* came from the timer, not from the callbacks. So renders were produced at times decoupled from when each surface should actually draw:

- The timer rate need not match a given output: a fixed ~60 Hz timer produces too few frames on a faster display.
- #612 paces the whole process at one rate (the maximum across monitors), so a surface on a slower output is driven by a timer faster than — and drifting in phase against — its own vblank.

Either way frames land at uneven intervals (and can miss a vblank and be held an extra cycle); because positions are time-based, uneven presentation becomes uneven on-screen motion. It is worst at 30 Hz, where a ~200 ms transition is only ~6 frames at ~33 ms each, so a single mistimed or duplicated frame is glaring.

## Change

Drive the loop via Wayland frame callbacks. The fixed-interval `thread::sleep` and the `prev_dur` backoff are removed; pacing now comes from the compositor's `wl_surface.frame` callbacks. Since the refresh rate is no longer computed, `get_refresh_rate` is removed entirely — including the `.unwrap_or(60)` fallback added in #617; with the function gone, the panic that #617 guarded against (no output reporting a `current` mode yet) can no longer occur.

## How pacing now follows `wl_surface.frame`

The panel's render was already gated on a per-surface `has_frame` flag — what was missing was letting that gate actually pace the loop. The flow:

1. The panel's Wayland connection to the compositor is registered as a `calloop` source (`WaylandSource`), so `event_loop.dispatch()` returns as soon as the compositor sends an event — including `wl_callback.done` for a frame callback.
2. The frame-callback handler sets `has_frame = true` for the matching layer surface (`CompositorHandler::frame` → `SpaceContainer::frame` → `PanelSpace::frame`).
3. The render path runs only when `is_dirty && has_frame` (`Space::render`). After committing a frame it requests the next callback via `wl_surface.frame` and clears `has_frame`.
4. During an animation the surface stays dirty, so the chain `render → wl_surface.frame → wl_callback.done → has_frame = true → render` is self-sustaining and paced entirely by the compositor's presentation timing.

Previously the trailing `thread::sleep` did **not** wake on the frame callback, so the render cadence followed the timer rather than each surface's presentation — drifting in phase against a slower output's vblank. Removing it lets `dispatch()` block on the callback instead: the loop wakes the moment the compositor is ready to present again and renders in the same iteration. Each layer surface (Panel, Dock) has its own `has_frame`, so each is paced by its own output's frame callbacks rather than a single process-wide rate.

The visible dispatch timeout is kept at 16 ms as an upper bound only: the embedded applet server is polled once per iteration via `dispatch_clients` (its fd is not a calloop source), so the ceiling stays tight (~60 Hz) to keep applet updates responsive. A frame callback wakes the loop earlier while animating.

## Testing

Test environment: hybrid AMD + NVIDIA laptop, rendering on the NVIDIA GPU — GeForce RTX 4070 Laptop (`10de:2860`), driver 580.159.03 (open kernel module), Wayland session. (Noted because cosmic-comp special-cases NVIDIA page-flip timing, so smoothness behaviour may differ on other GPUs/drivers.)

Built and run locally on a three-monitor setup, testing the autohide panel at 30 Hz, 60 Hz and 240 Hz outputs. Autohide is smooth at all three with this change. On the same setup #612 was choppy on a 30 Hz output — it paced the whole process at the single `max` refresh and rendered each surface on a looser, less vblank-aligned cadence — whereas this change renders each surface once per its own frame callback and is smooth there. At 240 Hz it matches #612's smoothness, confirming the 16 ms visible timeout is only an idle/applet-poll ceiling: during animation the frame callback (~4 ms) wakes `dispatch` well before it, so the loop runs at the display's rate. Idle CPU is on par with #612 (~1 %, dominated by applet background threads and ~60 Hz housekeeping; no busy-loop — `dispatch` blocks correctly), ~2–3 % during animation. No panics; logs clean.

Test method (without installing over the packaged binary): cosmic-session launches `cosmic-panel` by name via `PATH` lookup and auto-respawns it. I placed a symlink to the patched build in a directory that precedes `/usr/bin` in cosmic-session's `PATH` (`~/.cargo/bin`), then killed the running panel so the session respawned the patched binary — with its notifications socket coupling intact, since the respawn is handled by cosmic-session. The running binary was confirmed via `/proc/<pid>/exe`. Removing the symlink and killing the panel again restores the packaged binary.

Supersedes the pacing approach from #612.

---

- [ ] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [ ] I understand these changes in full and will be able to respond to review comments.
- [ ] My change is accurately described in the commit message.
- [ ] My contribution is tested and working as described.
- [ ] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.
