### PR TITLE
Return a fallback refresh rate instead of unwrapping

### DIFF
--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -96,14 +96,22 @@ pub fn run(
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
     fn get_refresh_rate(global_state: &GlobalState) -> i32 {
-        global_state.space.space_list.iter()
+        global_state
+            .space
+            .space_list
+            .iter()
             .filter_map(|panel| {
-                panel.output.as_ref()?.2.modes.iter()
+                panel
+                    .output
+                    .as_ref()?
+                    .2
+                    .modes
+                    .iter()
                     .find(|mode| mode.current)
                     .map(|mode| mode.refresh_rate)
             })
             .max()
-            .unwrap()
+            .unwrap_or(60)
     }
 
     let mut prev_refresh_rate = get_refresh_rate(&global_state);


### PR DESCRIPTION
- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

`get_refresh_rate()` can run before the space list has been initialized. This fixes it to return a 60Hz fallback value instead of crashing on `.unwrap()`.