### PR TITLE
fix: use panel color override on creation

### DIFF
--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -376,6 +376,7 @@ impl PanelSpace {
         let name = format!("{}-{}", config.name, config.output);
         let visibility =
             if config.autohide.is_some() { Visibility::Hidden } else { Visibility::Visible };
+        let color_override = config.bg_color_override();
         Self {
             config,
             shared: shared.clone(),
@@ -405,7 +406,7 @@ impl PanelSpace {
             start_instant: Instant::now(),
             s_focused_surface: Default::default(),
             s_hovered_surface: Default::default(),
-            colors: PanelColors::new(theme),
+            colors: PanelColors::new(theme).with_color_override(color_override),
             actual_size: (0, 0).into(),
             input_region: None,
             damage_tracked_renderer: None,


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

Currently the panel color overrides only takes effect on theme/config change. This hooks it up to correctly apply the override on initial creation as well.