### PR TITLE
fix: Ensure panel expansion to the edge with fractional scaling

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -795,6 +795,19 @@ impl PanelSpace {
         } else {
             (new_dim.w, new_dim.h)
         };
+
+        // Ensure expansion to the edge for fractional scaling
+        if self.config.expand_to_edges() && self.gap() == 0 {
+            let fill = |logical: i32| {
+                (((logical as f64 * self.scale).round() / self.scale).ceil() as i32).max(logical)
+            };
+            if self.config.is_horizontal() {
+                w = fill(w);
+            } else {
+                h = fill(h);
+            }
+        }
+
         if !self.background_element.as_ref().is_some_and(|e| {
             e.with_program(|p| {
                 p.logical_height == h


### PR DESCRIPTION
Currently the taskbar can undershoot by one pixel:
<img width="265" height="127" alt="ScalingIssue" src="https://github.com/user-attachments/assets/794c7b17-42d0-48eb-93c1-df1eec280625" />

The red line on the right is some bleed from my wallpaper.
I am in 3840x2160 at 175% scaling.

The issue comes from fractional scaling, logical size is calculated in smithay by: round(physical resolution / scaling).
logical = round(3840 / 1.75) = round(2194.285 714) = 2194

Then when it is rendered it is scaled to 2194*1.75 = 3839.5. This value is used as is, as a f32, in the rendering pipeline so the leftover 0.5 are left transparent and that's where the bleed happens(at least that's my understanding of it).

This fix favors overshooting the logical size, specifically when stretch to edge is set and gap is 0.

- [X] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [X] I understand these changes in full and will be able to respond to review comments.
- [X] My change is accurately described in the commit message.
- [X] My contribution is tested and working as described.
- [X] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

