### PR TITLE
Improve frame pacing of embedded applet popups

### DIFF
--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -20,6 +20,7 @@ use smithay::backend::renderer::element::utils::CropRenderElement;
 use smithay::backend::renderer::element::{AsRenderElements, RenderElement, UnderlyingStorage};
 use smithay::backend::renderer::gles::{GlesError, GlesFrame, GlesRenderer};
 use smithay::backend::renderer::{Bind, Color32F, Frame, Renderer};
+use smithay::desktop::utils::send_frames_surface_tree;
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Buffer, IsAlive, Physical, Point, Rectangle, user_data::UserDataMap};
 use smithay::wayland::seat::WaylandFocus;
@@ -298,6 +299,7 @@ impl PanelSpace {
             }
         }
         let clear_color = [0.0, 0.0, 0.0, 0.0];
+        let popup_output = self.output.as_ref().map(|(_, output, _)| output.clone());
         // TODO Popup rendering optimization
         for p in self.popups.iter_mut().filter(|p| {
             p.popup.dirty
@@ -338,6 +340,17 @@ impl PanelSpace {
             let mut dmg = res.damage.cloned();
 
             p.popup.egl_surface.as_ref().unwrap().swap_buffers(dmg.as_deref_mut())?;
+
+            if let Some(output) = popup_output.as_ref() {
+                let primary_output = output.clone();
+                send_frames_surface_tree(
+                    p.s_surface.wl_surface(),
+                    output,
+                    Duration::from_millis(time as u64),
+                    throttle,
+                    move |_, _| Some(primary_output.clone()),
+                );
+            }
 
             let wl_surface = p.popup.c_popup.wl_surface().clone();
             wl_surface.frame(qh, wl_surface.clone());

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -107,6 +107,19 @@ impl PanelSpace {
             return Ok(());
         }
 
+        // Throttle frame callbacks for embedded applets to the frame duration
+        // of this panel's output, so applets can animate at the full refresh
+        // rate of high-refresh displays; the caller-provided value is only a
+        // fallback for when the output's current mode is unknown.
+        let throttle = self
+            .output
+            .as_ref()
+            .and_then(|(_, _, info)| info.modes.iter().find(|mode| mode.current))
+            .filter(|mode| mode.refresh_rate > 0)
+            .map_or(throttle, |mode| {
+                Some(Duration::from_nanos(1_000_000_000_000 / mode.refresh_rate as u64))
+            });
+
         let clear_color = [0., 0., 0., 0.];
 
         if self.is_dirty && self.has_frame {
@@ -394,6 +407,17 @@ impl PanelSpace {
             let mut dmg = res.damage.cloned();
 
             subsurface.subsurface.egl_surface.swap_buffers(dmg.as_deref_mut())?;
+
+            if let Some(output) = popup_output.as_ref() {
+                let primary_output = output.clone();
+                send_frames_surface_tree(
+                    &subsurface.s_surface,
+                    output,
+                    Duration::from_millis(time as u64),
+                    throttle,
+                    move |_, _| Some(primary_output.clone()),
+                );
+            }
 
             let wl_surface = subsurface.subsurface.c_surface.clone();
             wl_surface.frame(qh, wl_surface.clone());

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -36,11 +36,11 @@ pub fn run(
     client_state: ClientState,
     embedded_server_state: ServerState,
     mut event_loop: calloop::EventLoop<'static, GlobalState>,
-    mut server_display: Display<GlobalState>,
+    server_display: Display<GlobalState>,
 ) -> Result<()> {
     let start = std::time::Instant::now();
 
-    let s_dh = server_display.handle();
+    let mut s_dh = server_display.handle();
     space.set_display_handle(s_dh.clone());
 
     let mut global_state = GlobalState::new(client_state, embedded_server_state, space, start);
@@ -92,27 +92,48 @@ pub fn run(
         .expect("Failed to insert cleanup timer.");
     global_state.bind_display(&s_dh);
 
+    // Register the embedded applet server's poll fd as an event source, so
+    // that applet requests wake `event_loop.dispatch` and are handled
+    // immediately instead of being polled once per loop iteration. This is
+    // what allows the loop timeouts below to be generous without hurting
+    // applet responsiveness.
+    handle
+        .insert_source(
+            calloop::generic::Generic::new(
+                server_display,
+                calloop::Interest::READ,
+                calloop::Mode::Level,
+            ),
+            |_, display, state| {
+                // SAFETY: the display is neither dropped nor replaced
+                let display = unsafe { display.get_mut() };
+                display.dispatch_clients(state)?;
+                display.flush_clients()?;
+                Ok(calloop::PostAction::Continue)
+            },
+        )
+        .expect("Failed to insert embedded wayland server source.");
+
     // TODO find better place for this
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
     // Pacing is driven by frame callbacks (`wl_surface.frame`), not a fixed
-    // timer. The Wayland client connection is a calloop source, so
-    // `event_loop.dispatch` returns as soon as the compositor sends the next
-    // frame callback. Rendering is gated on `has_frame` (see `Space::render`),
-    // so the panel emits at most one frame per callback and animates at the
-    // display's presentation rate without needing to know the refresh rate.
-    // The timeouts below are only upper bounds for when nothing else wakes us.
+    // timer. The Wayland client connection and the embedded applet server are
+    // both calloop sources, so `event_loop.dispatch` returns as soon as the
+    // compositor sends the next frame callback or an applet sends a request.
+    // Rendering is gated on `has_frame` (see `Space::render`), so the panel
+    // emits at most one frame per callback and animates at the display's
+    // presentation rate without needing to know the refresh rate.
     loop {
-        // Ceiling on how long to block, not the frame interval: a frame callback
-        // wakes `dispatch` earlier while animating, so animation is paced at the
-        // display's refresh rate. The embedded applet server is polled once per
-        // iteration via `dispatch_clients` (its fd is not a calloop source), so
-        // the visible ceiling stays tight (~60 Hz) to keep applet updates
-        // responsive; hidden panels can idle longer.
+        // The timeout is only a ceiling for time-based state that is polled in
+        // `handle_events` rather than event-driven: the autohide
+        // `hide_wait`/show-delay checks in `PanelSpace::handle_focus` and the
+        // debounced iced updates. Everything latency-sensitive (input, frame
+        // callbacks, applet requests) wakes `dispatch` through its own source.
         let dispatch_timeout = if matches!(global_state.space.visibility(), Visibility::Hidden) {
             Duration::from_millis(300)
         } else {
-            Duration::from_millis(16)
+            Duration::from_millis(100)
         };
 
         event_loop.dispatch(dispatch_timeout, &mut global_state)?;
@@ -126,7 +147,10 @@ pub fn run(
                 &global_state.client_state.queue_handle,
                 &mut global_state.server_state.popup_manager,
                 global_state.start_time.elapsed().as_millis().try_into()?,
-                Some(dispatch_timeout),
+                // Fallback frame-callback throttle for embedded applets;
+                // panels override it with the frame duration of their own
+                // output (see `PanelSpace::render`).
+                Some(Duration::from_millis(16)),
             );
         }
         global_state.draw_dnd_icon();
@@ -138,11 +162,10 @@ pub fn run(
             );
         }
 
-        // dispatch server events
-        {
-            server_display.dispatch_clients(&mut global_state)?;
-            server_display.flush_clients()?;
-        }
+        // flush events generated for embedded clients while rendering (e.g.
+        // frame callbacks); their requests are dispatched by the server
+        // display's event source above
+        s_dh.flush_clients()?;
         global_state.iter_count += 1;
     }
 }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/mod.rs
@@ -3,7 +3,7 @@
 
 //! Provides the core functionality for cosmic-panel
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::Result;
 use sctk::shm::multi::MultiPool;
@@ -95,41 +95,27 @@ pub fn run(
     // TODO find better place for this
     // let set_clipboard_once = Rc::new(Cell::new(false));
 
-    fn get_refresh_rate(global_state: &GlobalState) -> i32 {
-        global_state
-            .space
-            .space_list
-            .iter()
-            .filter_map(|panel| {
-                panel
-                    .output
-                    .as_ref()?
-                    .2
-                    .modes
-                    .iter()
-                    .find(|mode| mode.current)
-                    .map(|mode| mode.refresh_rate)
-            })
-            .max()
-            .unwrap_or(60)
-    }
-
-    let mut prev_refresh_rate = get_refresh_rate(&global_state);
-    let mut prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
-
+    // Pacing is driven by frame callbacks (`wl_surface.frame`), not a fixed
+    // timer. The Wayland client connection is a calloop source, so
+    // `event_loop.dispatch` returns as soon as the compositor sends the next
+    // frame callback. Rendering is gated on `has_frame` (see `Space::render`),
+    // so the panel emits at most one frame per callback and animates at the
+    // display's presentation rate without needing to know the refresh rate.
+    // The timeouts below are only upper bounds for when nothing else wakes us.
     loop {
-        let iter_start = Instant::now();
-
-        let visibility = matches!(global_state.space.visibility(), Visibility::Hidden);
-        // dispatch desktop client events
-        let dur = if matches!(global_state.space.visibility(), Visibility::Hidden) {
+        // Ceiling on how long to block, not the frame interval: a frame callback
+        // wakes `dispatch` earlier while animating, so animation is paced at the
+        // display's refresh rate. The embedded applet server is polled once per
+        // iteration via `dispatch_clients` (its fd is not a calloop source), so
+        // the visible ceiling stays tight (~60 Hz) to keep applet updates
+        // responsive; hidden panels can idle longer.
+        let dispatch_timeout = if matches!(global_state.space.visibility(), Visibility::Hidden) {
             Duration::from_millis(300)
         } else {
-            Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64)
-        }
-        .max(prev_dur);
+            Duration::from_millis(16)
+        };
 
-        event_loop.dispatch(dur, &mut global_state)?;
+        event_loop.dispatch(dispatch_timeout, &mut global_state)?;
 
         // rendering
         {
@@ -140,7 +126,7 @@ pub fn run(
                 &global_state.client_state.queue_handle,
                 &mut global_state.server_state.popup_manager,
                 global_state.start_time.elapsed().as_millis().try_into()?,
-                Some(dur),
+                Some(dispatch_timeout),
             );
         }
         global_state.draw_dnd_icon();
@@ -158,25 +144,5 @@ pub fn run(
             server_display.flush_clients()?;
         }
         global_state.iter_count += 1;
-
-        let new_visibility_hidden = matches!(global_state.space.visibility(), Visibility::Hidden);
-
-        if visibility != new_visibility_hidden {
-            prev_refresh_rate = get_refresh_rate(&global_state);
-            prev_dur = Duration::from_nanos(1_000_000_000_000 / prev_refresh_rate as u64);
-            continue;
-        }
-        if let Some(dur) = Instant::now()
-            .checked_duration_since(iter_start)
-            .and_then(|spent| dur.checked_sub(spent))
-        {
-            std::thread::sleep(dur.min(Duration::from_nanos(if new_visibility_hidden {
-                50_000_000
-            } else {
-                1_000_000_000_000 / prev_refresh_rate as u64
-            })));
-        } else {
-            prev_dur = prev_dur.checked_mul(2).unwrap_or(prev_dur).min(Duration::from_millis(100));
-        }
     }
 }

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/mod.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/mod.rs
@@ -430,12 +430,17 @@ impl DmabufHandler for GlobalState {
         &mut self,
         _global: &smithay::wayland::dmabuf::DmabufGlobal,
         dmabuf: smithay::backend::allocator::dmabuf::Dmabuf,
-        _: ImportNotifier,
+        notifier: ImportNotifier,
     ) {
-        if let Some(Err(err)) =
-            self.space.renderer().map(|renderer| renderer.import_dmabuf(&dmabuf, None))
-        {
-            error!("Failed to import dmabuf: {}", err);
+        match self.space.renderer().map(|renderer| renderer.import_dmabuf(&dmabuf, None)) {
+            Some(Ok(_)) => {
+                let _ = notifier.successful::<GlobalState>();
+            },
+            Some(Err(err)) => {
+                error!("Failed to import dmabuf: {}", err);
+                notifier.failed();
+            },
+            None => notifier.failed(),
         }
     }
 }


### PR DESCRIPTION
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.


## Summary

This PR improves `cosmic-panel`'s embedded Wayland applet rendering path by making the panel loop more event-driven and by sending frame callbacks for embedded popup/subsurface trees.

The main changes are:

* register the embedded applet server display as a `calloop` source, so applet requests wake the event loop immediately instead of being polled once per render-loop iteration;
* remove the manual `thread::sleep` / `prev_dur` pacing logic and let rendering be paced by `wl_surface.frame` callbacks;
* use the panel output's current refresh rate as the frame-callback throttle for embedded applets, with the caller-provided value only as a fallback;
* send frame callbacks for embedded popup and subsurface surface trees after rendering them;
* report `zwp_linux_dmabuf` import success/failure through `ImportNotifier`.

## Problem

The panel render loop was partly event-driven and partly timer-driven. Rendering was already gated on frame availability, but the outer loop still used a fixed/refresh-derived dispatch timeout plus a manual sleep/backoff path. In practice this can make applets and panel animations less responsive than the compositor's actual presentation cadence, especially after the loop backs off or when surfaces live on outputs with different refresh rates.

Embedded applet requests were also dispatched only once per loop iteration. That means applet-side activity did not wake the event loop by itself, so generous dispatch timeouts could improve idle behaviour at the cost of applet responsiveness.

For embedded popups/subsurfaces, the panel rendered and swapped buffers but did not send frame callbacks for those surface trees. Animated applet popups therefore could miss the normal `render -> frame callback -> next render` feedback loop.

## Change

The embedded applet server display is now inserted into the main `calloop` event loop as a readable source. When an embedded applet sends requests, the loop wakes immediately, dispatches the applet clients, and flushes responses.

The render loop no longer does manual sleeping or exponential duration backoff. The visible/hidden dispatch timeout is only a ceiling for non-latency-critical polled state; latency-sensitive events such as compositor frame callbacks and embedded applet requests wake the loop through their own event sources.

For embedded applet frame callbacks, `PanelSpace::render` now derives the throttle from the panel output's current mode when available. This makes the callback interval per-output instead of using a process-wide refresh-rate approximation.

After rendering embedded popup and subsurface buffers, the panel now calls `send_frames_surface_tree` for the corresponding surface tree. This gives embedded popup/subsurface content the same frame-callback feedback loop as other rendered surfaces.

The dmabuf import path now reports the result to the client via `ImportNotifier`: success when the renderer imports the dmabuf, failure when import fails or no renderer is available.

## Relation to existing work

This builds on the same general pacing problem addressed by #612 and overlaps conceptually with #616, but additionally makes the embedded applet server itself event-driven and sends frame callbacks for embedded popup/subsurface trees.

## Testing

Tested locally with applets, original and custom. This is "after"

https://github.com/user-attachments/assets/a58b8c29-a106-4a19-8cda-a01c5eeaf70e




I tried to make "before", but had some issues with OBS (today is the 3rd time in my life when I'm using obs, haha), and latency and broken animation from OBS's video aren't so annoying as in the real life action. When I fix OBS, I will add the video in comments. IMHO it feels like a diff between 35 fps and 144 fps in online game. 


Things I checked:

* panel/dock animations remain smooth;
* applet interactions wake/respond without waiting for the next polling iteration;
* popup/subsurface applet content continues to update;
* no busy loop while idle;
* dmabuf import failures are reported instead of being silently ignored.
* (not confirmed) memory usage decrease
My setup has amd gpu and single 75hz monitor, but nvidia/intel should works, tests are highly welcome,