### PR TITLE
fix: don't create duplicate ext_background_effect_surface_v1 per commit

### DIFF
--- a/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/ext_background_effect.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/server/handlers/ext_background_effect.rs
@@ -51,14 +51,24 @@ impl BlurHandler for GlobalState {
                 continue;
             }
 
-            let Some(ext_background_effect_manager) =
-                self.client_state.ext_background_effect_manager.as_mut()
-            else {
-                break;
-            };
+            // Reuse an existing background-effect object for this surface instead of
+            // creating a new one on every commit: `ext_background_effect_v1` forbids
+            // attaching a second background-effect object to the same wl_surface, and
+            // doing so is a fatal protocol error that kills the whole connection.
+            let effect_surface = if let Some(existing) = blur_surface.as_ref() {
+                existing.clone()
+            } else {
+                let Some(ext_background_effect_manager) =
+                    self.client_state.ext_background_effect_manager.as_mut()
+                else {
+                    break;
+                };
 
-            let new_blur_surface = ext_background_effect_manager
-                .blur(c_layer_shell_surface.wl_surface(), &self.client_state.queue_handle);
+                let new_blur_surface = ext_background_effect_manager
+                    .blur(c_layer_shell_surface.wl_surface(), &self.client_state.queue_handle);
+                *blur_surface = Some(new_blur_surface.clone());
+                new_blur_surface
+            };
 
             if let Some(ref region) = region {
                 let Ok(wl_region) = Region::new(&self.client_state.compositor_state) else {
@@ -67,12 +77,10 @@ impl BlurHandler for GlobalState {
                 for r in region {
                     wl_region.add(r.loc.x, r.loc.y, r.size.w, r.size.h);
                 }
-                new_blur_surface.set_blur_region(Some(wl_region.wl_region()));
+                effect_surface.set_blur_region(Some(wl_region.wl_region()));
             } else {
-                new_blur_surface.set_blur_region(None);
+                effect_surface.set_blur_region(None);
             }
-
-            *blur_surface = Some(new_blur_surface);
         }
     }
 }


### PR DESCRIPTION
commit_blur() ran on every buffer commit for each proxied layer surface and unconditionally created a new
ext_background_effect_surface_v1 for it, overwriting the previously stored handle without destroying it. ext-background-effect-v1 only allows one background-effect object per wl_surface, so the second attach is a fatal protocol error, killing the panel's connection to the compositor.

This mostly went unnoticed because very few applets create their own extra layer-shell surface that gets proxied by the panel. Applets that do (e.g. a full-screen colour-picker overlay) commit repeatedly, which reliably reproduces it.

Reuse the existing background-effect object for a surface if one is already stored, only creating a new one when there isn't one yet, matching the pattern already used in commit_popup_blur() and enable_blur_capacity().

Fixes #637

- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

