### PR TITLE
fix: apply blur from correct source after applets rearranged

### DIFF
--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -40,6 +40,7 @@ use smithay::reexports::wayland_server::{self};
 use smithay::wayland::shell::xdg::ToplevelSurface;
 use tokio::sync::mpsc;
 use tracing::{error, info};
+use wayland_protocols::ext::background_effect::v1::client::ext_background_effect_manager_v1::ExtBackgroundEffectManagerV1;
 use wayland_server::Resource;
 
 pub struct SpaceContainer {
@@ -62,6 +63,7 @@ pub struct SpaceContainer {
     pub(crate) overlap_notify: Option<OverlapNotifyV1>,
     pub(crate) shared: Rc<PanelSharedState>,
     pub(crate) corner_radius_manager: Option<CosmicCornerRadiusManagerV1>,
+    pub(crate) blur_manager: Option<ExtBackgroundEffectManagerV1>,
 }
 
 impl SpaceContainer {
@@ -146,6 +148,7 @@ impl SpaceContainer {
                 workspaces_shown: Cell::new(false),
             }),
             corner_radius_manager: None,
+            blur_manager: None,
         }
     }
 
@@ -371,11 +374,10 @@ impl SpaceContainer {
             return;
         }
 
-        let mut blur_manager = None;
+        let blur_manager = self.blur_manager.clone();
         let mut was_blurred = false;
         // remove old one if it exists
         self.space_list.retain(|s| {
-            blur_manager = s.blur_manager.clone();
             // keep if the name is different or the output is different
             let keep = s.config.name != entry.name
                 || force_output.is_some()
@@ -460,10 +462,9 @@ impl SpaceContainer {
                 if !is_recreated {
                     continue;
                 }
-                let mut space_blur_manager = None;
+                let space_blur_manager = self.blur_manager.clone();
                 // remove old one if it exists
                 self.space_list.retain(|s| {
-                    space_blur_manager = s.blur_manager.clone();
                     // keep if the name is different or the output is different
                     s.config.name != c.name
                         || s.output.as_ref().is_some_and(|(_, o, _)| o.name() != output_name)

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/shared_state.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/shared_state.rs
@@ -225,6 +225,8 @@ impl GlobalState {
 
     pub(crate) fn enable_blur_capacity(&mut self) {
         self.client_state.blur_enabled = true;
+        self.space.blur_manager =
+            self.client_state.ext_background_effect_manager.as_ref().map(|bm| bm.manager.clone());
         for space in &mut self.space.space_list {
             space.enable_blur_capacity(
                 self.client_state.ext_background_effect_manager.as_ref().map(|bm| &bm.manager),


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/pop-os/cosmic-settings/pull/2069#issuecomment-4927261508. 

The panel turns transparent (instead of blurred) if you rearrange applets in cosmic-settings.
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

