### PR TITLE
fix: set min size for `anchor_rect`

### DIFF
--- a/cosmic-panel-bin/src/space/overflow.rs
+++ b/cosmic-panel-bin/src/space/overflow.rs
@@ -63,7 +63,7 @@ impl PanelSpace {
         let positioner = XdgPositioner::new(xdg_shell_state).unwrap();
         let popup_bbox = popup_element.geometry();
 
-        positioner.set_anchor_rect(loc.x, loc.y, bbox.size.w, bbox.size.h);
+        positioner.set_anchor_rect(loc.x, loc.y, bbox.size.w.max(1), bbox.size.h.max(1));
         let pixel_offset = 8;
         let (offset, anchor, gravity) = match self.config.anchor {
             PanelAnchor::Left => ((pixel_offset, 0), Anchor::Right, Gravity::Right),
@@ -82,7 +82,7 @@ impl PanelSpace {
         positioner.set_offset(offset.0, offset.1);
         positioner.set_reactive();
 
-        positioner.set_size(popup_bbox.size.w, popup_bbox.size.h);
+        positioner.set_size(popup_bbox.size.w.max(1), popup_bbox.size.h.max(1));
         let c_popup = popup::Popup::from_surface(
             None,
             &positioner,

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -1638,8 +1638,8 @@ impl PanelSpace {
         positioner.set_anchor_rect(
             anchor_rect.loc.x + p_offset.x,
             anchor_rect.loc.y + p_offset.y,
-            anchor_rect.size.w,
-            anchor_rect.size.h,
+            anchor_rect.size.w.max(1),
+            anchor_rect.size.h.max(1),
         );
         positioner.set_anchor(Anchor::try_from(anchor_edges as u32).unwrap_or(Anchor::None));
         positioner.set_gravity(Gravity::try_from(gravity as u32).unwrap_or(Gravity::None));


### PR DESCRIPTION
I'm developing an applet and noticed it's crashing the panel sometimes.

This guard fixes the issue. The same guard exists elsewhere, I assume `set_anchor_rect` and `set_size` where missed.

The panel crashes with these messages in the logs:
```
cosmic-session[5523]: xdg_positioner#1062: error 0: Invalid size for positioner's anchor rectangle.
cosmic-session[5523]: Protocol error 0 on object xdg_positioner@1062
```
___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

