### PR TITLE
fix: panel crashes when changing output scale due to small intermediate size

### DIFF
--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -1458,9 +1458,16 @@ impl PanelSpace {
                         };
                         let _ = renderer.bind(egl_surface);
 
-                        egl_surface.resize(scaled_size.w, scaled_size.h, 0, 0);
-                        if let Some(viewport) = self.layer_viewport.as_ref() {
-                            viewport.set_destination(dim.w.max(1), dim.h.max(1));
+                        // The panel deliberately collapses to a degenerate size to force a
+                        // reconfigure but that size must not be *published*
+                        // to the compositor because a too-small surface causes fatal
+                        // `radius_too_large`. `render()` already refuses to
+                        // draw below 20px keep the published size in lockstep with that.
+                        if dim.w > 20 && dim.h > 20 {
+                            egl_surface.resize(scaled_size.w, scaled_size.h, 0, 0);
+                            if let Some(viewport) = self.layer_viewport.as_ref() {
+                                viewport.set_destination(dim.w.max(1), dim.h.max(1));
+                            }
                         }
                     }
 
@@ -1502,10 +1509,13 @@ impl PanelSpace {
                     _ = unsafe { renderer.egl_context().make_current_with_surface(egl_surface) };
                     let _ = renderer.bind(egl_surface);
                     let scaled_size = dim.to_f64().to_physical(self.scale).to_i32_round();
-                    egl_surface.resize(scaled_size.w, scaled_size.h, 0, 0);
-
-                    if let Some(viewport) = self.layer_viewport.as_ref() {
-                        viewport.set_destination(dim.w, dim.h);
+                    // See note in the other resize branch (never publish a degenerate intermediate
+                    // size)
+                    if dim.w > 20 && dim.h > 20 {
+                        egl_surface.resize(scaled_size.w, scaled_size.h, 0, 0);
+                        if let Some(viewport) = self.layer_viewport.as_ref() {
+                            viewport.set_destination(dim.w, dim.h);
+                        }
                     }
                 }
                 self.dimensions = (dim.w, dim.h).into();


### PR DESCRIPTION
This fixes the disappearing panel that people have reported in mattermost: [This](https://chat.pop-os.org/pop-os/pl/rrowqbhtaj8w8mgzfigp7xr1so) and potentially [this](https://chat.pop-os.org/pop-os/pl/xz7qi7idci8m9neynsbeuoc7we).


To recreate the issue:
1- make sure the dock is enabled, gap is enabled, extend to edges is disabled.
2- change scale to higher numbers, at some point it will crash and/or disappear.


___
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

