### PR TITLE
Fix high cpu usage when screen is locked

### DIFF
--- a/cosmic-panel-bin/src/space/layout.rs
+++ b/cosmic-panel-bin/src/space/layout.rs
@@ -67,6 +67,7 @@ impl ShrinkablePadding {
 
 impl PanelSpace {
     pub(crate) fn layout_(&mut self) -> anyhow::Result<()> {
+        self.needs_layout = false;
         self.remap_attempts = self.remap_attempts.saturating_sub(1);
 
         let make_indices_contiguous =
@@ -451,6 +452,7 @@ impl PanelSpace {
         if new_list_thickness_dim != list_cross {
             self.pending_dimensions = Some(new_dim);
             self.is_dirty = true;
+            self.needs_layout = true;
             anyhow::bail!("resizing list");
         }
         let left_sum = left_sum_scaled / self.scale;
@@ -534,6 +536,7 @@ impl PanelSpace {
         } else if center_overflow > 0 {
             let overflow = self.shrink_center((center_sum - target_center_len) as u32);
             self.is_dirty = true;
+            self.needs_layout = true;
             bail!("overflow: {}", overflow)
         }
 
@@ -546,6 +549,7 @@ impl PanelSpace {
                 info!("target: {target_left_len}, actual: {left_sum}");
                 let overflow = self.shrink_left(left_overflow as u32);
                 self.is_dirty = true;
+                self.needs_layout = true;
 
                 bail!("left overflow: {} {}", left_overflow, overflow)
             }
@@ -559,6 +563,7 @@ impl PanelSpace {
             } else if right_overflow > 0 {
                 let overflow = self.shrink_right(right_overflow as u32);
                 self.is_dirty = true;
+                self.needs_layout = true;
 
                 bail!("right overflow: {} {}", right_overflow, overflow)
             }
@@ -852,6 +857,7 @@ impl PanelSpace {
 
             let Some(output) = self.output.as_ref().map(|o| o.1.clone()) else {
                 self.is_dirty = true;
+                self.needs_layout = true;
                 bail!("output missing");
             };
             let mut loc = match self.config.anchor {
@@ -1498,6 +1504,7 @@ impl PanelSpace {
             overflow_space.map_element(new_popup, (0, 0), false);
 
             self.is_dirty = true;
+            self.needs_layout = true;
             self.space.refresh();
         }
         let id = match section {
@@ -1534,6 +1541,7 @@ impl PanelSpace {
             );
             self.space.refresh();
             self.is_dirty = true;
+            self.needs_layout = true;
         }
         overflow
     }
@@ -1799,6 +1807,7 @@ impl PanelSpace {
                 });
                 w.refresh();
                 self.is_dirty = true;
+                self.needs_layout = true;
             }
         }
     }

--- a/cosmic-panel-bin/src/space/panel_space.rs
+++ b/cosmic-panel-bin/src/space/panel_space.rs
@@ -340,6 +340,11 @@ pub struct PanelSpace {
     // Logical size of the panel, with the applied animation state
     pub container_length: i32,
     pub is_dirty: bool,
+    /// Set alongside `is_dirty`, cleared when a layout pass runs, unlike
+    /// `is_dirty`, which is only cleared after rendering.
+    /// Keeping these separate prevents a layout loop while frame callbacks
+    /// are not being processed for example when the session is locked.
+    pub needs_layout: bool,
     pub space_event: Rc<Cell<Option<SpaceEvent>>>,
     pub s_focused_surface: ServerFocus,
     pub s_hovered_surface: ServerPtrFocus,
@@ -443,6 +448,7 @@ impl PanelSpace {
             input_region: None,
             damage_tracked_renderer: None,
             is_dirty: false,
+            needs_layout: false,
             has_frame: true,
             scale: 1.0,
             animate_state: None,
@@ -509,6 +515,7 @@ impl PanelSpace {
 
     pub fn apply_layer_overlaps(&mut self) {
         self.is_dirty = true;
+        self.needs_layout = true;
         self.is_background_dirty = true;
         self.logical_layer_start_overlap = 0;
         self.logical_layer_end_overlap = 0;
@@ -864,6 +871,7 @@ impl PanelSpace {
                             PanelAnchor::Top | PanelAnchor::Bottom => -(self.dimensions.h),
                         } + self.config.get_hide_handle() as i32;
                         self.is_dirty = true;
+                        self.needs_layout = true;
                         self.visibility = Visibility::TransitionToVisible {
                             last_instant: Instant::now(),
                             progress: Duration::new(0, 0),
@@ -895,6 +903,7 @@ impl PanelSpace {
                     {
                         self.transitioning = true;
                         self.is_dirty = true;
+                        self.needs_layout = true;
                         self.visibility = Visibility::TransitionToHidden {
                             last_instant: Instant::now(),
                             progress: Duration::new(0, 0),
@@ -921,6 +930,7 @@ impl PanelSpace {
                     smootherstep(progress.as_millis() as f32 / total_t.as_millis() as f32);
                 let handle = self.config.get_hide_handle() as i32;
                 self.is_dirty = true;
+                self.needs_layout = true;
 
                 if matches!(cur_hover, FocusStatus::Focused)
                     || (intellihide && !self.has_toplevel_overlap())
@@ -983,6 +993,7 @@ impl PanelSpace {
                     smootherstep(progress.as_millis() as f32 / total_t.as_millis() as f32);
                 let handle = self.config.get_hide_handle() as i32;
                 self.is_dirty = true;
+                self.needs_layout = true;
 
                 if matches!(cur_hover, FocusStatus::LastFocused(_))
                     && (!intellihide || !self.has_toplevel_overlap())
@@ -1054,6 +1065,7 @@ impl PanelSpace {
 
             self.transitioning = true;
             self.is_dirty = true;
+            self.needs_layout = true;
             let _panel_size =
                 if self.config().is_horizontal() { self.dimensions.h } else { self.dimensions.w };
 
@@ -1140,6 +1152,7 @@ impl PanelSpace {
                 as f32)
                 / animation_state.duration.as_millis() as f32;
             self.is_dirty = true;
+            self.needs_layout = true;
             if progress >= 1.0 {
                 tracing::info!("Animation finished, setting bg_color to end value");
                 if let CosmicPanelBackground::Color(c) = self.config.background {
@@ -1192,6 +1205,7 @@ impl PanelSpace {
             return;
         }
         self.is_dirty = true;
+        self.needs_layout = true;
         self.additional_gap = gap;
         let intellihide = self.overlap_notify.is_some();
         if ((intellihide && !self.has_toplevel_overlap())
@@ -1283,7 +1297,7 @@ impl PanelSpace {
                     info!("{:?}", self.space_event);
                 } else if self.layer.is_some() {
                     should_render = true;
-                    if self.is_dirty {
+                    if self.needs_layout {
                         _ = self.layout_();
                     }
                 }
@@ -1340,6 +1354,7 @@ impl PanelSpace {
         renderer: &mut Option<GlesRenderer>,
     ) {
         self.is_dirty = true;
+        self.needs_layout = true;
         let (w, h) = configure.new_size;
         match self.space_event.take() {
             Some(e) => match e {
@@ -1585,6 +1600,7 @@ impl PanelSpace {
     /// clear the panel
     pub fn clear(&mut self) {
         self.is_dirty = true;
+        self.needs_layout = true;
         self.close_popups(|_| false);
         self.overflow_popup = None;
         self.damage_tracked_renderer = Some(OutputDamageTracker::new(
@@ -1752,6 +1768,7 @@ impl PanelSpace {
                 needs_commit = true;
             }
             self.is_dirty = true;
+            self.needs_layout = true;
         }
 
         if config.anchor_gap != self.config.anchor_gap {
@@ -1900,6 +1917,7 @@ impl PanelSpace {
             return;
         };
         self.is_dirty = true;
+        self.needs_layout = true;
         self.space.refresh();
 
         let mut s_bbox = bbox_from_surface_tree(wlsurface, (0, 0));
@@ -2144,6 +2162,7 @@ impl PanelSpace {
             self.blur_manager = None;
         }
         self.is_dirty = true;
+        self.needs_layout = true;
     }
 
     pub(crate) fn update_popup_corners(

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -137,6 +137,7 @@ impl WrapperSpace for PanelSpace {
 
     fn add_window(&mut self, w: Window) {
         self.is_dirty = true;
+        self.needs_layout = true;
         if let Some(t) = w.toplevel() {
             t.with_pending_state(|state| {
                 state.size = None;
@@ -820,6 +821,7 @@ impl WrapperSpace for PanelSpace {
 
     fn dirty_window(&mut self, _dh: &DisplayHandle, s: &s_WlSurface) {
         self.is_dirty = true;
+        self.needs_layout = true;
         self.last_dirty = Some(Instant::now());
         if let Some(w) = self
             .space
@@ -853,6 +855,7 @@ impl WrapperSpace for PanelSpace {
 
     fn dirty_popup(&mut self, _dh: &DisplayHandle, s: &s_WlSurface) {
         self.is_dirty = true;
+        self.needs_layout = true;
         self.space.refresh();
 
         if let Some(p) = self.popups.iter_mut().find(|p| p.s_surface.wl_surface() == s) {
@@ -1594,6 +1597,7 @@ impl WrapperSpace for PanelSpace {
         self.dimensions = dimensions;
         self.space_event = next_render_event;
         self.is_dirty = true;
+        self.needs_layout = true;
         self.left_overflow_button_id = id::Id::new(format!("left_overflow_button_{}", self.id()));
         self.right_overflow_button_id = id::Id::new(format!("right_overflow_button_{}", self.id()));
         self.center_overflow_button_id =

--- a/cosmic-panel-bin/src/space_container/space_container.rs
+++ b/cosmic-panel-bin/src/space_container/space_container.rs
@@ -213,6 +213,7 @@ impl SpaceContainer {
             });
             if found_window || len != s.popups.len() {
                 s.is_dirty = true;
+                s.needs_layout = true;
                 break;
             }
         }
@@ -571,6 +572,7 @@ impl SpaceContainer {
         for space in &mut self.space_list {
             if space.space.id() == panel_id {
                 space.is_dirty = true;
+                space.needs_layout = true;
                 break;
             }
         }


### PR DESCRIPTION
`is_dirty` is cleared only in `render` but when screen is locked we don't get any render callbacks. So, `is_dirty` stays true and we get stuck in a relayout loop.

I introduced a new flag that clears `needs_layout` so we don't redo layout, and `is_dirty` will be cleared whenever we `render`.

Fixes https://github.com/pop-os/cosmic-panel/issues/645
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

