### PR TITLE
fix: don't map applet popups before their grab is forwarded

### DIFF
--- a/cosmic-panel-bin/src/space/overflow.rs
+++ b/cosmic-panel-bin/src/space/overflow.rs
@@ -166,6 +166,7 @@ impl PanelSpace {
                 input_region: None,
                 parent: self.layer.as_ref().unwrap().wl_surface().clone(),
                 grab: true,
+                pending_initial_commit: false,
                 blur_surface,
                 corner_radius,
             },

--- a/cosmic-panel-bin/src/space/render.rs
+++ b/cosmic-panel-bin/src/space/render.rs
@@ -322,6 +322,7 @@ impl PanelSpace {
                 && p.s_surface.alive()
                 && p.popup.c_popup.wl_surface().is_alive()
                 && p.popup.has_frame
+                && !p.popup.pending_initial_commit
         }) {
             if let Err(err) = unsafe {
                 renderer

--- a/cosmic-panel-bin/src/space/wrapper_space.rs
+++ b/cosmic-panel-bin/src/space/wrapper_space.rs
@@ -291,9 +291,6 @@ impl WrapperSpace for PanelSpace {
             c_wl_surface.set_buffer_scale(self.scale as i32);
         }
 
-        // must be done after role is assigned as popup
-        c_wl_surface.commit();
-
         let cur_popup_state = Some(WrapperPopupState::WaitConfigure);
         tracing::info!("adding popup to popups");
         self.popups.push(WrapperPopup {
@@ -319,6 +316,7 @@ impl WrapperSpace for PanelSpace {
                     .map(|p| p.wl_surface().clone())
                     .unwrap_or(self.layer.as_ref().unwrap().wl_surface().clone()),
                 grab: true,
+                pending_initial_commit: true,
                 blur_surface: None,
                 corner_radius: None,
             },
@@ -335,7 +333,7 @@ impl WrapperSpace for PanelSpace {
         serial: u32,
     ) -> anyhow::Result<()> {
         if let Some(p) = self.popups.iter().find(|wp| wp.s_surface == popup) {
-            p.popup.c_popup.xdg_popup().grab(&seat, serial);
+            p.popup.forward_grab(&seat, serial);
         }
         Ok(())
     }
@@ -862,6 +860,10 @@ impl WrapperSpace for PanelSpace {
         self.space.refresh();
 
         if let Some(p) = self.popups.iter_mut().find(|p| p.s_surface.wl_surface() == s) {
+            // the client is done setting up its popup, and any `grab` it requested has
+            // been forwarded from the pre-commit hook that runs before this
+            p.popup.map();
+
             let p_bbox = bbox_from_surface_tree(p.s_surface.wl_surface(), (0, 0));
             if p_bbox.size == p.popup.rectangle.size {
                 p.popup.dirty = true;

--- a/cosmic-panel-bin/src/xdg_shell_wrapper/space/popup.rs
+++ b/cosmic-panel-bin/src/xdg_shell_wrapper/space/popup.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
+use cctk::wayland_client::protocol::wl_seat::WlSeat;
 use cctk::wayland_client::protocol::wl_surface::WlSurface;
 use cosmic_protocols::corner_radius::v1::client::cosmic_corner_radius_toplevel_v1::CosmicCornerRadiusToplevelV1;
 use sctk::compositor::Region;
@@ -94,6 +95,34 @@ pub struct PanelPopup {
     pub parent: WlSurface,
     /// has a grab
     pub grab: bool,
+    /// `c_popup` has not been committed yet, so it is not mapped and may still
+    /// be grabbed. See [`PanelPopup::map`].
+    pub pending_initial_commit: bool,
+}
+
+impl PanelPopup {
+    /// Commit the popup we created in the compositor, mapping it.
+    ///
+    /// For a popup proxied from an embedded client this is deferred until that
+    /// client commits its own popup surface, because `xdg_popup.grab` is only
+    /// valid before the popup is mapped and smithay reports the client's `grab`
+    /// request from the pre-commit hook of that first commit. Mapping any earlier
+    /// turns every forwarded grab into an `invalid_grab` protocol error.
+    pub fn map(&mut self) {
+        if self.pending_initial_commit {
+            self.pending_initial_commit = false;
+            self.c_popup.wl_surface().commit();
+        }
+    }
+
+    /// Forward an `xdg_popup.grab` request from the embedded client.
+    pub fn forward_grab(&self, seat: &WlSeat, serial: u32) {
+        if self.pending_initial_commit {
+            self.c_popup.xdg_popup().grab(seat, serial);
+        } else {
+            tracing::warn!("Ignoring `grab` request for a popup that is already mapped");
+        }
+    }
 }
 
 impl WrapperPopup {


### PR DESCRIPTION
Fixes  `Protocol error 0 on object xdg_popup` error. 

[mattermost](https://chat.pop-os.org/pop-os/pl/mmh1ya3kypgyjjxcf3jmqokb7a)
____
- [x] I have disclosed use of any AI generated code in my commit messages.
  - If you are using an LLM, and do not fully understand the changes it is making to the code base, do not create a PR.
  - In our experience, AI generated code often results in overly complex code that lacks enough context for a proper fix or feature inclusion. This results in considerably longer code reviews. Due to this, AI authored or partially authored PRs may be closed without comment.
- [x] I understand these changes in full and will be able to respond to review comments.
- [x] My change is accurately described in the commit message.
- [x] My contribution is tested and working as described.
- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/) and certify my contribution under its conditions.

